### PR TITLE
Move the shared example.

### DIFF
--- a/spec/support/shared/docker_runnable_example.rb
+++ b/spec/support/shared/docker_runnable_example.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-shared_examples "a docker runnable model" do
+shared_examples_for "a docker runnable model" do
   let(:name) { 'FOO' }
   let(:from) { 'panamax/image' }
 


### PR DESCRIPTION
So we don't load it twice.
see: https://github.com/rspec/rspec-core/issues/828
