### PR TITLE
Fixing service pre-/post-exec lifecycle actions

### DIFF
--- a/lib/panamax_agent/fleet/service_definition.rb
+++ b/lib/panamax_agent/fleet/service_definition.rb
@@ -21,6 +21,8 @@ module PanamaxAgent
         self.exec_stop = attrs[:exec_stop]
         self.exec_stop_post = attrs[:exec_stop_post]
         self.restart_sec = attrs[:restart_sec]
+
+        yield self if block_given?
       end
 
       def to_hash

--- a/spec/lib/panamax_agent/fleet/service_definition_spec.rb
+++ b/spec/lib/panamax_agent/fleet/service_definition_spec.rb
@@ -19,7 +19,7 @@ describe PanamaxAgent::Fleet::ServiceDefinition do
     }
   end
 
-  subject { PanamaxAgent::Fleet::ServiceDefinition.new(name) }
+  subject { described_class.new(name) }
 
   it { should respond_to :name }
   it { should respond_to :description }
@@ -35,7 +35,7 @@ describe PanamaxAgent::Fleet::ServiceDefinition do
 
   describe '#initialize' do
 
-    subject { PanamaxAgent::Fleet::ServiceDefinition.new(name, attrs) }
+    subject { described_class.new(name, attrs) }
 
     its(:name) { should eql name }
     its(:description) { should eql attrs[:description] }
@@ -47,11 +47,20 @@ describe PanamaxAgent::Fleet::ServiceDefinition do
     its(:exec_stop) { should eql attrs[:exec_stop] }
     its(:exec_stop_post) { should eql attrs[:exec_stop_post] }
     its(:restart_sec) { should eql attrs[:restart_sec] }
+
+    context 'when a block is specified' do
+
+      it 'yields itself' do
+        yielded_instance = nil
+        new_instance = described_class.new(name) { |i| yielded_instance = i }
+        expect(yielded_instance).to be new_instance
+      end
+    end
   end
 
   describe '#to_hash' do
 
-    subject { PanamaxAgent::Fleet::ServiceDefinition.new(name, attrs) }
+    subject { described_class.new(name, attrs) }
 
     it 'provides a JSON formatted service definition' do
       expected = {
@@ -82,7 +91,7 @@ describe PanamaxAgent::Fleet::ServiceDefinition do
 
     context 'when the service name does not end in .service' do
 
-      subject { PanamaxAgent::Fleet::ServiceDefinition.new('foo') }
+      subject { described_class.new('foo') }
 
       it 'appends .service to the service name' do
         expected = {
@@ -105,7 +114,7 @@ describe PanamaxAgent::Fleet::ServiceDefinition do
 
       let(:after) { ['a', 'b'] }
 
-      subject { PanamaxAgent::Fleet::ServiceDefinition.new('foo', after: after) }
+      subject { described_class.new('foo', after: after) }
 
       it 'generates a space-delimited list of after requirements' do
         expected = {
@@ -130,7 +139,7 @@ describe PanamaxAgent::Fleet::ServiceDefinition do
 
       let(:requires) { ['a', 'b'] }
 
-      subject { PanamaxAgent::Fleet::ServiceDefinition.new('foo', requires: requires) }
+      subject { described_class.new('foo', requires: requires) }
 
       it 'generates a space-delimited list of requires requirements' do
         expected = {

--- a/spec/services/app_executer_spec.rb
+++ b/spec/services/app_executer_spec.rb
@@ -31,7 +31,9 @@ describe AppExecutor do
 
   before do
     PanamaxAgent.stub(:fleet_client).and_return(fake_fleet_client)
-    PanamaxAgent::Fleet::ServiceDefinition.stub(:new).and_return(fake_service_definition)
+    PanamaxAgent::Fleet::ServiceDefinition.stub(:new)
+      .and_yield(fake_service_definition)
+      .and_return(fake_service_definition)
   end
 
   describe '.run' do
@@ -40,11 +42,11 @@ describe AppExecutor do
       expect(fake_service_definition).to receive(:description=).with(service_description)
       expect(fake_service_definition).to receive(:after=).with('some-service.service')
       expect(fake_service_definition).to receive(:requires=).with('some-service.service')
-      expect(fake_service_definition).to receive(:exec_start_pre=).with('/usr/bin/docker ps -a -q | xargs docker rm')
+      expect(fake_service_definition).to receive(:exec_start_pre=).with("-/usr/bin/docker rm #{service_name}")
       expect(fake_service_definition).to receive(:exec_start=).with(docker_run_string)
-      expect(fake_service_definition).to receive(:exec_start_post=).with('/usr/bin/docker ps -a -q | xargs docker rm')
-      expect(fake_service_definition).to receive(:exec_stop=).with("/usr/bin/docker kill #{service_name} ; /usr/bin/docker rm #{service_name}")
-      expect(fake_service_definition).to receive(:exec_stop_post=).with('/usr/bin/docker ps -a -q | xargs docker rm')
+      expect(fake_service_definition).to receive(:exec_start_post=).with("-/usr/bin/docker rm #{service_name}")
+      expect(fake_service_definition).to receive(:exec_stop=).with("/usr/bin/docker kill #{service_name}")
+      expect(fake_service_definition).to receive(:exec_stop_post=).with("-/usr/bin/docker rm #{service_name}")
       expect(fake_service_definition).to receive(:restart_sec=).with('10')
       expect(fake_fleet_client).to receive(:submit).with(fake_service_definition)
 


### PR DESCRIPTION
Updating the default ExecStartPre/ExecStartPost/ExecStopPost commands we're generating for the service definition.

Also includes a refactoring of the ServiceDefinition `initialize` method so that it can accept a block.
