### PR TITLE
Raise errors from PanamaxAgent

### DIFF
--- a/lib/panamax_agent/connection.rb
+++ b/lib/panamax_agent/connection.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'panamax_agent/middleware/response/raise_error'
 
 module PanamaxAgent
   module Connection
@@ -7,6 +8,7 @@ module PanamaxAgent
       Faraday.new(options) do |faraday|
         faraday.request request_type
         faraday.response :json
+        faraday.response :raise_error
         faraday.adapter adapter
       end
     end

--- a/lib/panamax_agent/error.rb
+++ b/lib/panamax_agent/error.rb
@@ -1,0 +1,41 @@
+module PanamaxAgent
+
+  class Error < StandardError
+    attr_reader :error_code
+    attr_reader :cause
+
+    def initialize(msg, error_code=nil, cause=nil)
+      super(msg)
+      @error_code = error_code
+      @cause = cause
+    end
+
+    HTTP_CODE_MAP = {
+      400 => 'BadRequest',
+      401 => 'Unauthorized',
+      403 => 'Forbidden',
+      404 => 'NotFound',
+      405 => 'MethodNotAllowed',
+      406 => 'NotAcceptable',
+      408 => 'RequestTimeout',
+      409 => 'Conflict',
+      412 => 'PreconditionFailed',
+      413 => 'RequestEntityTooLarge',
+      414 => 'RequestUriTooLong',
+      415 => 'UnsupportedMediaType',
+      416 => 'RequestRangeNotSatisfiable',
+      417 => 'ExpectationFailed',
+      500 => 'InternalServerError',
+      501 => 'NotImplemented',
+      502 => 'BadGateway',
+      503 => 'ServiceUnavailable',
+      504 => 'GatewayTimeout'
+    }
+  end
+
+  # Define a new error class for all of the HTTP codes in the HTTP_CODE_MAP
+  Error::HTTP_CODE_MAP.each do |code, class_name|
+    PanamaxAgent.const_set(class_name, Class.new(Error)).const_set('HTTP_CODE', code)
+  end
+
+end

--- a/lib/panamax_agent/middleware/response/raise_error.rb
+++ b/lib/panamax_agent/middleware/response/raise_error.rb
@@ -1,0 +1,35 @@
+require 'faraday'
+require 'json'
+
+module PanamaxAgent::Response
+
+  class RaiseError < Faraday::Response::Middleware
+
+    def on_complete(env)
+      status = env[:status].to_i
+
+      if (400..600).include?(status)
+        error = parse_error(env[:body])
+
+        # Find the error class that matches the HTTP status code. Default to
+        # Error if no matching class exists.
+        class_name = PanamaxAgent::Error::HTTP_CODE_MAP.fetch(status, 'Error')
+
+        raise PanamaxAgent.const_get(class_name).new(
+          error['message'],
+          error['errorCode'],
+          error['cause'])
+      end
+    end
+
+    private
+
+    def parse_error(body)
+      JSON.parse(body)
+    rescue Exception
+      { 'message' => body }
+    end
+  end
+
+  Faraday.register_middleware :response, raise_error: lambda { RaiseError }
+end

--- a/spec/lib/panamax_agent/connection_spec.rb
+++ b/spec/lib/panamax_agent/connection_spec.rb
@@ -10,6 +10,7 @@ describe PanamaxAgent::Connection do
       handlers = [
         FaradayMiddleware::EncodeJson,
         FaradayMiddleware::ParseJson,
+        PanamaxAgent::Response::RaiseError,
         Faraday::Adapter::NetHttp
       ]
 
@@ -28,6 +29,7 @@ describe PanamaxAgent::Connection do
       handlers = [
         Faraday::Request::UrlEncoded,
         FaradayMiddleware::ParseJson,
+        PanamaxAgent::Response::RaiseError,
         Faraday::Adapter::NetHttp
       ]
 

--- a/spec/lib/panamax_agent/error_spec.rb
+++ b/spec/lib/panamax_agent/error_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe PanamaxAgent::Error do
+
+  let(:message) { 'some message' }
+  let(:error_code) { 12345 }
+  let(:cause) { 'user error' }
+
+  subject { PanamaxAgent::Error.new(message, error_code, cause) }
+
+  it { should respond_to(:message) }
+  it { should respond_to(:error_code) }
+  it { should respond_to(:cause) }
+
+  describe '#initialize' do
+
+    it 'saves the passed-in message' do
+      expect(subject.message).to eq message
+    end
+
+    it 'saves the passed-in error code' do
+      expect(subject.error_code).to eq error_code
+    end
+
+    it 'saves the passed-in cause' do
+      expect(subject.cause).to eq cause
+    end
+  end
+end

--- a/spec/lib/panamax_agent/middleware/response/raise_error_spec.rb
+++ b/spec/lib/panamax_agent/middleware/response/raise_error_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe PanamaxAgent::Response::RaiseError do
+
+  describe '#on_complete' do
+
+    context 'when HTTP status is 200' do
+
+      let(:env) { { status: 200 } }
+
+      it 'raises no errors' do
+        expect { subject.on_complete(env) }.to_not raise_error
+      end
+    end
+
+    context 'when the HTTP status is a known error (404)' do
+
+      let(:message) { 'not found' }
+      let(:error_code) { 999 }
+      let(:cause) { 'just because ' }
+
+      let(:env) do
+        {
+          status: 404,
+          body: "{ \"message\": \"#{message}\", \"errorCode\": #{error_code}, \"cause\": \"#{cause}\" }"
+        }
+      end
+
+      it 'raises a NotFound execption' do
+        expect { subject.on_complete(env) }.to raise_error(PanamaxAgent::NotFound)
+      end
+
+      it 'sets the message on the exception' do
+        begin
+          subject.on_complete(env)
+        rescue PanamaxAgent::NotFound => ex
+          expect(ex.message).to eq message
+        end
+      end
+
+      it 'sets the error code on the exception' do
+        begin
+          subject.on_complete(env)
+        rescue PanamaxAgent::NotFound => ex
+          expect(ex.error_code).to eq error_code
+        end
+      end
+
+      it 'sets the cause on the exception' do
+        begin
+          subject.on_complete(env)
+        rescue PanamaxAgent::NotFound => ex
+          expect(ex.cause).to eq cause
+        end
+      end
+    end
+
+    context 'when HTTP status is an unknown error' do
+
+      let(:env) do
+        {
+          status: 499,
+          body: "{ \"message\": \"err\" }"
+        }
+      end
+
+      it 'raises an Error execption' do
+        expect { subject.on_complete(env) }.to raise_error(PanamaxAgent::Error)
+      end
+    end
+
+    context 'when error body is not JSON parseable' do
+
+      let(:env) do
+        {
+          status: 499,
+          body: "FOO BAR"
+        }
+      end
+
+      it 'sets the error message to be the response body' do
+        begin
+          subject.on_complete(env)
+        rescue PanamaxAgent::Error => ex
+          expect(ex.message).to eq env[:body]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to provide better error information back to the consumer of the panamax-api we want to raise errors related to any problems submitting services to etcd.

I've implemented a Faraday middleware which looks for HTTP error codes and will raise a corresponding exception with details about the problem.

[#69643856]
