### PR TITLE
Remove data format support from journal client

### DIFF
--- a/lib/panamax_agent/configuration.rb
+++ b/lib/panamax_agent/configuration.rb
@@ -11,7 +11,6 @@ module PanamaxAgent
       :etcd_api_url,
       :etcd_api_version,
       :journal_api_url,
-      :journal_data_format,
       :open_timeout,
       :read_timeout,
       :ssl_options,
@@ -25,7 +24,6 @@ module PanamaxAgent
     DEFAULT_ETCD_API_URL = ENV['FLEETCTL_ENDPOINT']
     DEFAULT_ETCD_API_VERSION = 'v2'
     DEFAULT_JOURNAL_API_URL = ENV['JOURNAL_ENDPOINT']
-    DEFAULT_JOURNAL_DATA_FORMAT = :json
     DEFAULT_OPEN_TIMEOUT = 2
     DEFAULT_READ_TIMEOUT = 5
     DEFAULT_SSL_OPTIONS = { verify: false }
@@ -49,7 +47,6 @@ module PanamaxAgent
       self.etcd_api_url = DEFAULT_ETCD_API_URL
       self.etcd_api_version = DEFAULT_ETCD_API_VERSION
       self.journal_api_url = DEFAULT_JOURNAL_API_URL
-      self.journal_data_format = DEFAULT_JOURNAL_DATA_FORMAT
       self.open_timeout = DEFAULT_OPEN_TIMEOUT
       self.read_timeout = DEFAULT_READ_TIMEOUT
       self.ssl_options = DEFAULT_SSL_OPTIONS

--- a/lib/panamax_agent/journal/client.rb
+++ b/lib/panamax_agent/journal/client.rb
@@ -7,13 +7,6 @@ module PanamaxAgent
   module Journal
     class Client < PanamaxAgent::Client
 
-      JOURNAL_DATA_FORMAT = {
-          :text     => 'text/plain',
-          :json     => 'application/json',
-          :json_sse => 'application/event-stream',
-          :export   => 'application/vnd.fdo.journal'
-      }
-
       VALID_JOURNAL_FIELDS = [
           'PRIORITY',          # [0-6]
           'MESSAGE',
@@ -31,13 +24,6 @@ module PanamaxAgent
       def initialize(options={})
         super
         @url = self.journal_api_url
-        @data_format = JOURNAL_DATA_FORMAT[self.journal_data_format]
-      end
-
-      def data_format=(new_format)
-        if JOURNAL_DATA_FORMAT.include?(new_format)
-          @data_format = JOURNAL_DATA_FORMAT[new_format]
-        end
       end
 
       include PanamaxAgent::Journal::Client::Machine

--- a/lib/panamax_agent/journal/client/entries.rb
+++ b/lib/panamax_agent/journal/client/entries.rb
@@ -12,13 +12,10 @@ module PanamaxAgent
         #             : 99999 - special value to show entries from all boots
         ###
         def get_entries_by_fields(fieldpairs={}, boot_offset=0)
-          boot = {}
-          boot['boot'] = boot_offset unless boot_offset == 99999
-          opts = boot.merge!(remove_invalid_fieldpairs(fieldpairs))
+          opts = remove_invalid_fieldpairs(fieldpairs)
+          opts['boot'] = boot_offset unless boot_offset == 99999
 
-          get(entries_path,
-              opts,
-              headers={ accept: "#{@data_format}"})
+          get(entries_path, opts)
         end
 
         private

--- a/lib/panamax_agent/journal/client/fields.rb
+++ b/lib/panamax_agent/journal/client/fields.rb
@@ -8,9 +8,7 @@ module PanamaxAgent
         def get_values_by_field(field)
           if valid?(field)
             opts = {}
-            get(fields_path(field),
-                opts,
-                headers={ accept: "#{@data_format}"})
+            get(fields_path(field), opts)
           end
         end
 

--- a/spec/lib/panamax_agent/journal/client/entries_spec.rb
+++ b/spec/lib/panamax_agent/journal/client/entries_spec.rb
@@ -29,9 +29,8 @@ describe PanamaxAgent::Journal::Client::Entries do
     VALID_FIELDPAIRS_FOR_ENTRIES.each do |key, value|
       opts[key] = value
       it "GETs the entries resource for key - #{key}=#{value}" do
-        headers = { accept: 'application/json'}
         expect(subject).to receive(:get)
-                           .with("entries", opts, headers)
+                           .with("entries", opts)
                            .and_return(response)
 
         subject.get_entries_by_fields(opts)
@@ -48,9 +47,8 @@ describe PanamaxAgent::Journal::Client::Entries do
     VALID_FIELDPAIRS_FOR_ENTRIES.each do |key, value|
       opts[key] = value
       it "GETs the entries resource for key - #{key}=#{value}" do
-        headers = { accept: 'application/json'}
         expect(subject).to receive(:get)
-                           .with("entries", opts, headers)
+                           .with("entries", opts)
                            .and_return(response)
 
         subject.get_entries_by_fields(opts, 99999)
@@ -66,9 +64,8 @@ describe PanamaxAgent::Journal::Client::Entries do
     opts = {'boot' => 0}.merge!(VALID_FIELDPAIRS_FOR_ENTRIES)
 
     it 'GETs the entries resource for multiple keys' do
-      headers = { accept: 'application/json'}
       expect(subject).to receive(:get)
-                         .with("entries", opts, headers)
+                         .with("entries", opts)
                          .and_return(response)
 
       subject.get_entries_by_fields(opts)
@@ -82,9 +79,8 @@ describe PanamaxAgent::Journal::Client::Entries do
     opts = {'boot' => 99999}.merge!(VALID_FIELDPAIRS_FOR_ENTRIES)
 
     it 'GETs the entries resource for multiple keys' do
-      headers = { accept: 'application/json'}
       expect(subject).to receive(:get)
-                         .with("entries", opts, headers)
+                         .with("entries", opts)
                          .and_return(response)
 
       subject.get_entries_by_fields(opts, 99999)

--- a/spec/lib/panamax_agent/journal/client/fields_spec.rb
+++ b/spec/lib/panamax_agent/journal/client/fields_spec.rb
@@ -31,7 +31,7 @@ describe PanamaxAgent::Journal::Client::Fields do
       it "GETs the values for the field - #{field}" do
         headers = { accept: 'application/json'}
         expect(subject).to receive(:get)
-                           .with("fields/#{field}", opts, headers)
+                           .with("fields/#{field}", opts)
                            .and_return(response)
 
         subject.get_values_by_field(field)


### PR DESCRIPTION
This is a proposed change to journal client PR. @rupakg was trying to support multiple data formats for the journal response -- while the journal API does support these, they don't work well with the way that we're using Faraday to parse response. If the user were to choose the text/plain format, we'd need to define a separate Faraday middleware stack to avoid trying to parse the response as JSON.

Since we're only planning on consuming the JSON-formatted journal output at this time, the simplest thing to do is remove support for the other response formats.
