### PR TITLE
User docker pull in service unit file

### DIFF
--- a/app/services/service_manager.rb
+++ b/app/services/service_manager.rb
@@ -48,7 +48,7 @@ class ServiceManager
       # don't really care if it fails.
       docker_rm = "-/usr/bin/docker rm #{service.name}"
 
-      sd.exec_start_pre = docker_rm
+      sd.exec_start_pre = "-/usr/bin/docker pull #{service.from}"
       sd.exec_start = service.docker_run_string
       sd.exec_start_post = docker_rm
       sd.exec_stop = "/usr/bin/docker kill #{service.name}"

--- a/spec/services/service_manager_spec.rb
+++ b/spec/services/service_manager_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe ServiceManager do
 
   let(:service_name) { 'wordpress' }
+  let(:image_name) { 'some_image' }
   let(:service_description) { 'A wordpress service' }
   let(:fake_fleet_client) do
     double(:fake_fleet_client,
@@ -16,7 +17,8 @@ describe ServiceManager do
   let(:service) do
     Service.new(
       name: service_name,
-      description: service_description
+      description: service_description,
+      from: image_name
     )
   end
 
@@ -83,7 +85,7 @@ describe ServiceManager do
         expect(service_def.description).to eq service_description
         expect(service_def.after).to eq linked_to_service.unit_name
         expect(service_def.requires).to eq linked_to_service.unit_name
-        expect(service_def.exec_start_pre).to eq "-/usr/bin/docker rm #{service_name}"
+        expect(service_def.exec_start_pre).to eq "-/usr/bin/docker pull #{image_name}"
         expect(service_def.exec_start).to eq docker_run_string
         expect(service_def.exec_start_post).to eq "-/usr/bin/docker rm #{service_name}"
         expect(service_def.exec_stop).to eq "/usr/bin/docker kill #{service_name}"


### PR DESCRIPTION
Using `docker pull` in the `ExecStartPre` block of our service unit file will allow us to report better service status to the user.

Previously, if the user didn't already have the image on their system, it would get pulled down automatically as part of the `docker run` command. However, everything that happens as part of `docker run` is part of the _running_ state as far as fleet is concerned. So Fleet will report that the service is running, but it may actually be engaged in a lengthy image download.

By forcing a `docker pull` in the pre block Fleet will instead report that the service is in the "start-pre" state while the image is being downloaded and won't show as "running" until the container has been started.

For use cases where the image has already been pulled-down, this change will make no difference, but when the image needs to be downloaded the experience should be a lot better for the user.
