### PR TITLE
Add service to an existing app.

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -25,6 +25,14 @@ class ServicesController < ApplicationController
     respond_with app.services.find(params[:id]).destroy
   end
 
+  def create
+    service = app.add_service(service_create_params)
+    if service
+      app.restart
+    end
+    render json: service
+  end
+
   private
 
   def app
@@ -35,6 +43,21 @@ class ServicesController < ApplicationController
     params.permit(
       :name,
       :description,
+      :ports => [[:host_interface, :host_port, :container_port, :proto]],
+      :expose => [],
+      :volumes => [[:host_path, :container_path]],
+      :links => [[:service_id, :alias]]
+    ).tap do |whitelisted|
+      whitelisted[:environment] = params[:environment]
+    end
+  end
+
+  def service_create_params
+    params.permit(
+      :name,
+      :description,
+      :from,
+      :categories => [[:id]],
       :ports => [[:host_interface, :host_port, :container_port, :proto]],
       :expose => [],
       :volumes => [[:host_path, :container_path]],

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -27,6 +27,33 @@ class App < ActiveRecord::Base
     services.each(&:start)
   end
 
+  def restart
+    services.each(&:restart)
+  end
+
+  def add_service(service_create_params)
+    links = service_create_params.delete(:links)
+    categories = service_create_params.delete(:categories)
+    service = Service.new(service_create_params)
+    # add categories
+    if categories
+      categories.each do |category_id|
+        category = AppCategory.find(category_id)
+        service.categories << category if category
+      end
+    end
+    # add links
+    if links
+      links.each do |link|
+        linked_to_service = services.find(link[:service_id])
+        service.links << ServiceLink.new(linked_to_service: linked_to_service, alias: link[:alias])
+      end
+    end
+    services << service
+    self.save
+    service
+  end
+
   private
 
   def self.create_services(template, categories)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ PanamaxApi::Application.routes.draw do
 
   resources :templates, only: [:index, :show]
   resources :apps, only: [:index, :show, :create, :destroy] do
-    resources :services, only: [:index, :show, :update, :destroy] do
+    resources :services, only: [:index, :show, :create, :update, :destroy] do
       member do
         get :journal
       end

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -188,4 +188,69 @@ describe App do
       subject.run
     end
   end
+
+  describe '#restart' do
+
+    let(:s1) { Service.new(name: 's1') }
+    let(:s2) { Service.new(name: 's2') }
+
+    before do
+      subject.services = [s1, s2]
+    end
+
+    it 'restarts each service' do
+      expect(s1).to receive(:restart)
+      expect(s2).to receive(:restart)
+      subject.restart
+    end
+  end
+
+  describe '#add_service' do
+    let(:some_app) {App.new}
+    let(:category) {AppCategory.find(1)}
+    let(:params) do
+      {
+          name: 'foo_bar',
+          description: 'my foo service',
+          from: 'some image',
+          categories: [{ id: 1, id: 2}],
+          ports: [{host_interface: '', host_port: '', container_port: '', proto: ''}],
+          expose: [''],
+          links:[],
+          volumes: [{host_path: '', container_path: ''}],
+          environment: { 'SOME_KEY' => ''}
+      }
+    end
+    before do
+      App.stub(:find).and_return(some_app)
+      some_app.stub(:resolve_name_conflicts).and_return(true)
+      AppCategory.stub(:find).and_return(category)
+    end
+
+    it 'creates a new service' do
+      result = some_app.add_service(params)
+      expect(result.name).to eq 'foo_bar'
+      expect(result.from).to eq 'some image'
+    end
+
+    it 'increments the service count' do
+      expect {
+        some_app.add_service(params)
+      }.to change { Service.count }.by(1)
+    end
+
+    it 'adds the service to the existing app' do
+      some_app.add_service(params)
+      some_app.reload
+      expect(Service.last.app).to eq some_app
+    end
+
+    it 'increments the app services count' do
+      expect {
+        some_app.add_service(params)
+        some_app.reload
+      }.to change { some_app.services.count }.by(1)
+    end
+
+  end
 end


### PR DESCRIPTION
Adds the ability to add a new service to an existing application. It optionally expects a category to put the new service in, and can take links to other services in the existing application. It creates the new service, and then restarts the application, which in turn submits/starts the new service, and restarts the existing services for the application.
