### PR TITLE
Sanitize service names on name update.

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -122,12 +122,17 @@ class Service < ActiveRecord::Base
     bad_name.gsub(/[^0-9A-z.-]|[\^]|[\`]|[\[]|[\]]/, '_')
   end
 
-  def resolve_name_conflicts
+  def increment_name(name)
     unless persisted?
-      sanitized_name = sanitize_name(name)
-      count = Service.where('name LIKE ?', "#{sanitized_name}%").count
-      self.name = (count > 0) ? "#{sanitized_name}_#{count}" : sanitized_name
+      count = Service.where('name LIKE ?', "#{name}%").count
+      name = (count > 0) ? "#{name}_#{count}" : name
     end
+    name
+  end
+
+  def resolve_name_conflicts
+    sanitized_name = sanitize_name(name)
+    self.name = increment_name(sanitized_name)
   end
 
   def service_state

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -218,5 +218,23 @@ describe Service do
       expect(subject.update_with_relationships(attrs)).to eq true
     end
 
+    describe "#name=" do
+
+      let(:service) { Service.new(name:'foo') }
+      let(:attrs_with_bad_name){ { name: 'Foo123_- ~!@#$%&*()+={}|:;"\'<>,?^`][ -890baR'} }
+
+      before do
+        Service.stub(:find).and_return(service)
+      end
+
+      it 'sanitizes names with bad chars' do
+        expected_name = "Foo123_-_____________________________-890baR"
+        service.update_with_relationships(attrs_with_bad_name)
+        service.reload
+        expect(service.name).to eq(expected_name)
+        expect(service.name.length).to eq(expected_name.length)
+      end
+
+    end
   end
 end


### PR DESCRIPTION
The service names were not getting sanitized if the service name was updated with a name with bad chars.
