### PR TITLE
Fix service name collision in seeded templates.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,7 @@ rails = Template.create(
     recommended: true
 )
 rails.images.create(
-    name: 'DB',
+    name: 'DB_2',
     repository: 'dharmamike/dc-pgsql',
     tag: 'latest',
     description: 'PostgreSQL',
@@ -54,12 +54,12 @@ rails.images.create(
   repository: 'dharmamike/dc-rails',
   tag: 'latest',
   description: 'welcome to rails',
-  links: [{service: 'DB', alias:'DB_1'}],
+  links: [{service: 'DB_2', alias:'DB_1'}],
   ports: [{host_port: 8088, container_port: 3000}]
 )
 
 Template.create(
   name: 'Apache',
-  description: 'This is a reccomended apache template',
+  description: 'This is a recommended apache template',
   recommended: false
 )


### PR DESCRIPTION
Fixes [#70966304]

WP template has a service named 'DB_1'. The Rails template has a service named 'DB'. If an app is created from WP template, the service is named DB_1.service. Now, if another app is created with the Rails template, the name resolution logic looks for an existing service of LIKE %DB%, and finds one i.e. DB_1 that was created by the first app. So, the name gets resolved for the second app's db service to be DB_1. Baddddd.
The DB_1 service already exists, so the app fails with 'Key Already Exists'.

Fix is to not have a service name like XXX_1 along with a service named XXX.
