### PR TITLE
Increment service names if update causes service name collisions

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -126,7 +126,7 @@ class Service < ActiveRecord::Base
   end
 
   def increment_name(name)
-    unless persisted?
+    if self.name_changed? || !persisted?
       count = Service.where('name LIKE ?', "#{name}%").count
       name = (count > 0) ? "#{name}_#{count}" : name
     end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -253,12 +253,8 @@ describe Service do
 
     describe "#name=" do
 
-      let(:service) { Service.new(name:'foo') }
+      let(:service) { Service.create(name:'foo') }
       let(:attrs_with_bad_name){ { name: 'Foo123_- ~!@#$%&*()+={}|:;"\'<>,?^`][ -890baR'} }
-
-      before do
-        Service.stub(:find).and_return(service)
-      end
 
       it 'sanitizes names with bad chars' do
         expected_name = "Foo123_-_____________________________-890baR"
@@ -266,6 +262,21 @@ describe Service do
         service.reload
         expect(service.name).to eq(expected_name)
         expect(service.name.length).to eq(expected_name.length)
+      end
+
+      it 'appends an incremented count when service with updated name already exists' do
+        # simulate existing service
+        Service.create({ name: 'foo_bar' })
+        # update service name from 'foo' to 'foo_bar' which already exists
+        service.update_with_relationships({ name: 'foo_bar' })
+        service.reload
+        expect(service.name).to eq('foo_bar_1')
+      end
+
+      it 'appends an incremented count only if name is updated' do
+        service.update_with_relationships({ description: 'description for foo' })
+        service.reload
+        expect(service.name).to eq('foo')
       end
 
     end


### PR DESCRIPTION
Fixes [#70777634].

This PR fixes a bug where if the name of a service is updated to a name, which already exists as a service, the name is resolved. Example: A service is created with name "APPtastic", so a service named APPtastic.service was created. Another service already exists with name "APP", so a service named APP.service exists as well. Everything was fine, until, the app "APPtastic" was renamed to "APP". This PR will make sure that the renamed service is named APP_1.service appropriately.
