### PR TITLE
Push service state retrieval logic down to ServiceManager

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -24,16 +24,8 @@ class Service < ActiveRecord::Base
     "#{name}.service"
   end
 
-  def load_state
-    service_state['loadState']
-  end
-
-  def active_state
-    service_state['activeState']
-  end
-
-  def sub_state
-    service_state['subState']
+  def service_state
+    manager.get_state
   end
 
   def submit
@@ -108,12 +100,6 @@ class Service < ActiveRecord::Base
     )
   end
 
-  protected
-
-  def fleet_client
-    PanamaxAgent.fleet_client
-  end
-
   private
 
   def manager
@@ -137,15 +123,4 @@ class Service < ActiveRecord::Base
     sanitized_name = sanitize_name(name)
     self.name = increment_name(sanitized_name)
   end
-
-  def service_state
-    if not @service_state
-      fleet_state = fleet_client.get_state(unit_name)
-      @service_state = JSON.parse(fleet_state['node']['value'])
-    end
-    @service_state
-  rescue Exception
-    {}
-  end
-
 end

--- a/app/serializers/service_serializer.rb
+++ b/app/serializers/service_serializer.rb
@@ -9,4 +9,22 @@ class ServiceSerializer < ActiveModel::Serializer
   has_many :categories, serializer: CategorySerializer
 
   has_many :links, serializer: ServiceLinkSerializer
+
+  def load_state
+    service_state[:load_state]
+  end
+
+  def active_state
+    service_state[:active_state]
+  end
+
+  def sub_state
+    service_state[:sub_state]
+  end
+
+  private
+
+  def service_state
+    @service_state ||= object.service_state
+  end
 end

--- a/app/services/service_manager.rb
+++ b/app/services/service_manager.rb
@@ -28,6 +28,14 @@ class ServiceManager
     fleet_client.destroy(@service.unit_name)
   end
 
+  def get_state
+    fleet_state = fleet_client.get_state(@service.unit_name)
+    service_states = JSON.parse(fleet_state['node']['value'])
+    service_states.each_with_object({}) { |(k,v), hash| hash[k.underscore.to_sym] = v }
+  rescue Exception
+    {}
+  end
+
   private
 
   def fleet_client

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -6,7 +6,8 @@ describe Service do
     double(:dummy_manager,
       submit: true,
       start: true,
-      destroy: true
+      destroy: true,
+      get_state: { load_state: 'loaded' }
     )
   end
 
@@ -30,48 +31,10 @@ describe Service do
     end
   end
 
-  describe 'service states' do
-    let(:fleet_state) do
-      {
-          'node' => {
-              'value' => '{"loadState":"loaded", "activeState":"active","subState":"running"}'
-          }
-      }
+  describe '#service_state' do
+    it 'returns the service state from the service manager' do
+      expect(subject.service_state).to eql({ load_state: 'loaded' })
     end
-
-    let(:fleet_client) do
-      double(:fleet_client, get_state: fleet_state)
-    end
-
-    before do
-      PanamaxAgent.stub(:fleet_client).and_return(fleet_client)
-    end
-
-    [:load_state, :active_state, :sub_state].each do |attr|
-      it 'invokes the Fleet API' do
-        expect(PanamaxAgent.fleet_client).to receive(:get_state).with(subject.unit_name)
-        subject.send(attr)
-      end
-    end
-
-    describe 'load_state' do
-      it 'returns loadState from Fleet' do
-        expect(subject.load_state).to eq 'loaded'
-      end
-    end
-
-    describe 'active_state' do
-      it 'returns activeState from Fleet' do
-        expect(subject.active_state).to eq 'active'
-      end
-    end
-
-    describe 'sub_state' do
-      it 'returns subState from Fleet' do
-        expect(subject.sub_state).to eq 'running'
-      end
-    end
-
   end
 
   describe '.new_from_image' do

--- a/spec/services/service_manager_spec.rb
+++ b/spec/services/service_manager_spec.rb
@@ -5,6 +5,14 @@ describe ServiceManager do
   let(:service_name) { 'wordpress' }
   let(:image_name) { 'some_image' }
   let(:service_description) { 'A wordpress service' }
+  let(:service_state) do
+    {
+      'node' => {
+        'value' => '{"loadState":"loaded"}'
+      }
+    }
+  end
+
   let(:fake_fleet_client) do
     double(:fake_fleet_client,
       submit: true,
@@ -113,6 +121,29 @@ describe ServiceManager do
 
       it 'returns the result of the fleet call' do
         expect(subject.send(method)).to eql true
+      end
+    end
+  end
+
+  describe '#get_state' do
+
+    it 'retrieves service state from the fleet client' do
+      expect(fake_fleet_client).to receive(:get_state).with(service.unit_name)
+      subject.get_state
+    end
+
+    it 'returns the state hash w/ normalized keys' do
+
+    end
+
+    context 'when an error occurs while querying fleet' do
+
+      before do
+        fake_fleet_client.stub(:get_state).and_raise('boom')
+      end
+
+      it 'returns an empty hash' do
+        expect(subject.get_state).to eql({})
       end
     end
   end


### PR DESCRIPTION
Refactoring `Service` model so that all fleet interactions are pushed down in the service manager. This completes the work that was started when we added the submit/start/shutdown methods directly to the model.
