### PR TITLE
Add a start action to services.

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -33,6 +33,14 @@ class ServicesController < ApplicationController
     render json: service
   end
 
+  def start
+    service = app.services.find(params[:id])
+    if service && !service.started?
+      service.start
+    end
+    render json: service
+  end
+
   private
 
   def app

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -46,6 +46,10 @@ class Service < ActiveRecord::Base
     self.start
   end
 
+  def started?
+    !service_state.empty?
+  end
+
   def copy_categories_from_image(image, app_categories)
     image.categories.each do |image_cat|
       self.categories << app_categories.find { |app_cat| app_cat.name == image_cat.name }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ PanamaxApi::Application.routes.draw do
     resources :services, only: [:index, :show, :create, :update, :destroy] do
       member do
         get :journal
+        post :start
       end
     end
   end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -206,4 +206,42 @@ describe ServicesController do
 
   end
 
+  describe '#start' do
+    let(:dummy_app) { double(:app) }
+    let(:dummy_service) { Service.first }
+
+    before do
+      App.stub(:find).and_return(dummy_app)
+      dummy_app.stub_chain(:services, :find).and_return(dummy_service)
+      dummy_service.stub(:started?).and_return(false)
+      dummy_service.stub(:start).and_return(true)
+    end
+
+    context 'when service is not started' do
+      it 'starts the service' do
+        expect(dummy_service).to receive(:start)
+        post :start, { app_id: app.id, id: dummy_service.id, format: :json }
+      end
+      it 'returns the service in json as a response' do
+        post :start, { app_id: app.id, id: dummy_service.id, format: :json }
+        expect(response.body).to eq (ServiceSerializer.new(dummy_service)).to_json
+      end
+    end
+
+    context 'when service is already started' do
+      before do
+        dummy_service.stub(:started?).and_return(true)
+      end
+      it 'does nothing' do
+        expect(dummy_service).to_not receive(:start)
+        post :start, { app_id: app.id, id: dummy_service.id, format: :json }
+      end
+      it 'returns the service in json as a response' do
+        post :start, { app_id: app.id, id: dummy_service.id, format: :json }
+        expect(response.body).to eq (ServiceSerializer.new(dummy_service)).to_json
+      end
+    end
+
+
+  end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -37,6 +37,12 @@ describe Service do
     end
   end
 
+  describe '#started?' do
+    it 'service should be started' do
+      expect(subject.started?).to eql(true)
+    end
+  end
+
   describe '.new_from_image' do
     let(:fake_image) do
       double(:fake_image, {

--- a/spec/routing/apps_routes_spec.rb
+++ b/spec/routing/apps_routes_spec.rb
@@ -91,5 +91,14 @@ describe 'apps routes' do
                                )
     end
 
+    it 'routes post start to the app services controller start action' do
+      expect(post: '/apps/1/services/1/start').to route_to(
+                                                       controller: 'services',
+                                                       action: 'start',
+                                                       app_id: '1',
+                                                       id: '1'
+                                                   )
+    end
+
   end
 end


### PR DESCRIPTION
_ON HOLD_ 
Fixes [#71235968].

Adds a service action to 'start' a service. The REST interface is: 
POST /apps/:app_id/services/:service_id/start
