### PR TITLE
Add an api wrapper to return versions.

### DIFF
--- a/lib/panamax_agent/configuration.rb
+++ b/lib/panamax_agent/configuration.rb
@@ -11,6 +11,8 @@ module PanamaxAgent
       :etcd_api_url,
       :etcd_api_version,
       :journal_api_url,
+      :pmx_registry_api_url,
+      :pmx_registry_api_version,
       :open_timeout,
       :read_timeout,
       :ssl_options,
@@ -24,6 +26,8 @@ module PanamaxAgent
     DEFAULT_ETCD_API_URL = ENV['FLEETCTL_ENDPOINT']
     DEFAULT_ETCD_API_VERSION = 'v2'
     DEFAULT_JOURNAL_API_URL = ENV['JOURNAL_ENDPOINT']
+    DEFAULT_PMX_REGISTRY_API_URL = 'http://74.201.240.198:5000'
+    DEFAULT_PMX_REGISTRY_API_VERSION = 'v1'
     DEFAULT_OPEN_TIMEOUT = 2
     DEFAULT_READ_TIMEOUT = 5
     DEFAULT_SSL_OPTIONS = { verify: false }
@@ -47,6 +51,8 @@ module PanamaxAgent
       self.etcd_api_url = DEFAULT_ETCD_API_URL
       self.etcd_api_version = DEFAULT_ETCD_API_VERSION
       self.journal_api_url = DEFAULT_JOURNAL_API_URL
+      self.pmx_registry_api_url = DEFAULT_PMX_REGISTRY_API_URL
+      self.pmx_registry_api_version = DEFAULT_PMX_REGISTRY_API_VERSION
       self.open_timeout = DEFAULT_OPEN_TIMEOUT
       self.read_timeout = DEFAULT_READ_TIMEOUT
       self.ssl_options = DEFAULT_SSL_OPTIONS

--- a/lib/panamax_agent/panamax/client.rb
+++ b/lib/panamax_agent/panamax/client.rb
@@ -1,0 +1,19 @@
+require 'panamax_agent/client'
+require 'panamax_agent/panamax/client/components'
+
+module PanamaxAgent
+  module Panamax
+    class Client < PanamaxAgent::Client
+
+      attr_reader :registry_client
+
+      def initialize(options={})
+        super
+        @registry_client = PanamaxAgent::Registry::Client.new(:registry_api_url => pmx_registry_api_url, :registry_api_version => pmx_registry_api_version)
+      end
+
+      include PanamaxAgent::Panamax::Client::Components
+
+    end
+  end
+end

--- a/lib/panamax_agent/panamax/client/components.rb
+++ b/lib/panamax_agent/panamax/client/components.rb
@@ -1,0 +1,37 @@
+module PanamaxAgent
+  module Panamax
+    class Client < PanamaxAgent::Client
+      module Components
+
+        PANAMAX_COMPONENTS = ['panamax-ui', 'panamax-api']
+
+        def list_components
+          components = [{"panamax-agent" =>
+                          [{"versions" => {PanamaxAgent::VERSION => ""} }]
+                        } ]
+          PANAMAX_COMPONENTS.each do |component|
+            comp_metadata = []
+            comp_metadata << {"versions" => registry_client.list_repository_tags(component)}
+            components << { component => comp_metadata }
+          end
+          components
+        end
+
+        def get_component(component)
+          comp = []
+          if component == "panamax-agent"
+            comp_versions = {PanamaxAgent::VERSION => ""}
+            comp << {"versions" => comp_versions}
+          else
+            if PANAMAX_COMPONENTS.include?(component)
+              comp_versions = registry_client.list_repository_tags(component)
+              comp << {"versions" => comp_versions}
+            end
+          end
+          comp
+        end
+
+      end
+    end
+  end
+end

--- a/spec/lib/panamax_agent/panamax/client/versions_spec.rb
+++ b/spec/lib/panamax_agent/panamax/client/versions_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe PanamaxAgent::Panamax::Client::Components do
+
+  let(:fake_registry_client) { double(:fake_registry_client) }
+  subject { PanamaxAgent::Panamax::Client.new(registry_client: fake_registry_client) }
+
+  let(:expected_components) do
+    [{'panamax-agent' =>
+        [ { "versions"=>
+            {"0.0.1" => ""}
+          }
+        ]
+     },
+     {"panamax-ui"=>
+        [ { "versions"=>
+            {"0.0.1"=>
+                 "c621aba88fcdd1fc78d1be596efe91763edc69e8f6aefbd9e719dd556a6d65f0",
+             "0.0.2"=>
+                 "c621aba88fcdd1fc78d1be596efe91763edc69e8f6aefbd9e719dd556a6d65f0",
+             "0.0.3"=>
+                 "e7638cac6322860b5d1d6d93cb7f0cbd6430c7da29dbc39935589196e2c341b0",
+             "0.0.4"=>
+                 "373bc7e476c9ddfe33df55d8ad2c03574804e3fb4097420210df6dd1fe690fd7",
+             "dev"=>"373bc7e476c9ddfe33df55d8ad2c03574804e3fb4097420210df6dd1fe690fd7",
+             "latest"=>
+                 "373bc7e476c9ddfe33df55d8ad2c03574804e3fb4097420210df6dd1fe690fd7"
+            }
+          }
+        ]
+     },
+     {"panamax-api"=>
+        [ { "versions"=>
+            {"0.0.1"=>
+                 "66aa01032841e76126a9a31236194de563ef3f83bbfa1747e2a52b2861fe2b29",
+             "0.0.2"=>
+                 "ff1a3f25e0345bafadb32c1d268a300c73ced377b09f2f8d28fc7a0228e08bbf",
+             "0.0.3"=>
+                 "ff1a3f25e0345bafadb32c1d268a300c73ced377b09f2f8d28fc7a0228e08bbf",
+             "0.0.4"=>
+                 "ff1a3f25e0345bafadb32c1d268a300c73ced377b09f2f8d28fc7a0228e08bbf",
+             "0.1.0"=>
+                 "ff1a3f25e0345bafadb32c1d268a300c73ced377b09f2f8d28fc7a0228e08bbf",
+             "0.1.1"=>
+                 "08f5aff7f4eca2ce57c2d49fa1cefafe2b023eb18a7e4e6b1a599a350fc0a76a",
+             "0.1.2"=>
+                 "cc09435b159c8e6111928dc30e2188ae4b94c5cf734dfa8770b04e535f71aba8",
+             "dev"=>"cc09435b159c8e6111928dc30e2188ae4b94c5cf734dfa8770b04e535f71aba8",
+             "latest"=>
+                 "cc09435b159c8e6111928dc30e2188ae4b94c5cf734dfa8770b04e535f71aba8"
+            }
+          }
+        ]
+     }
+    ]
+  end
+
+  before do
+    PanamaxAgent::Registry::Client.stub(:new).and_return(fake_registry_client)
+    # fake_registry_client.stub(:list_repository_tags).with('panamax-agent').and_return(expected_components[0]['panamax-agent'])
+    fake_registry_client.stub(:list_repository_tags).with('panamax-ui').and_return(expected_components[1]['panamax-ui'][0]['versions'])
+    fake_registry_client.stub(:list_repository_tags).with('panamax-api').and_return(expected_components[2]['panamax-api'][0]['versions'])
+  end
+
+  describe '#list_components' do
+
+    it 'returns the metadata for all components' do
+      expect(subject.list_components).to eql(expected_components)
+    end
+  end
+
+  describe '#get_component' do
+
+    it 'returns the metadata info for the panamax ui component' do
+      expect(subject.get_component('panamax-ui')).to eql(expected_components[1]['panamax-ui'])
+    end
+
+    it 'returns the metadata info for the panamax api component' do
+      expect(subject.get_component('panamax-api')).to eql(expected_components[2]['panamax-api'])
+    end
+
+    it 'returns empty array for non panamax component' do
+      expect(subject.get_component('not-valid')).to eq []
+    end
+  end
+end


### PR DESCRIPTION
Fixes [#70050856].

This PR adds an api wrapper to return versions for panamax components.

pmx = PanamaxAgent::Panamax::Client.new
pmx.list_components
pmx.get_components('panamax-agent') 
pmx.get_components('panamax-ui')
pmx.get_components('panamax-api') 

Note: The latest rev. refactored the api to use 'components' vs. 'versions' nomenclature to support a generic way to return metadata for component(s). Version info. happens to be one of such metadata.
