### PR TITLE
Add custom responder for dealing w/ error responses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,8 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :null_session
+
+  # Use our custom responder which will return the full model representation
+  # when errors occur (the Rails default is to simply return the errors)
+  self.responder = FullResourceResponder
 end

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -22,16 +22,16 @@ class AppsController < ApplicationController
 
     if @app.valid?
       @app.run
-      render json: @app
     else
       logger.error("app validation failed: #{@app.errors.to_hash}")
-      render json: @app, status: :unprocessable_entity
     end
+
+    respond_with @app
   rescue => ex
     logger.error("app creation failed: #{ex.message}")
     @app.destroy
     @app.errors[:base] << ex.message
-    render json: @app, status: :unprocessable_entity
+    respond_with @app
   end
 
   def journal

--- a/lib/full_resource_responder.rb
+++ b/lib/full_resource_responder.rb
@@ -1,0 +1,9 @@
+class FullResourceResponder < ActionController::Responder
+
+  protected
+
+  def display_errors
+    controller.render format => resource, :status => :unprocessable_entity
+  end
+
+end

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -136,7 +136,7 @@ describe AppsController do
 
       it 'returns no errors' do
         post :create, params.merge(format: :json)
-        expect(response.status).to eq 200
+        expect(response.status).to eq 201
       end
 
     end


### PR DESCRIPTION
@alexwelch this should allow us to continue using `respond_with` but get the behavior we want when returning error information (i.e. return the full model representation, not just the errors).
