### PR TITLE
Add a wrapper to the github api to manage files on repos.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'faraday_middleware'
 gem 'jbuilder', '~> 2.0'
 gem 'docker-api', '1.9.0', require: 'docker'
 gem 'active_model_serializers'
+gem 'octokit', '~> 3.0'
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.6)
     archive-tar-minitar (0.5.2)
     arel (5.0.1.20140414130214)
     builder (3.2.2)
@@ -64,6 +65,8 @@ GEM
     minitest (5.3.3)
     multi_json (1.9.2)
     multipart-post (1.2.0)
+    octokit (3.1.0)
+      sawyer (~> 0.5.3)
     polyglot (0.3.4)
     rack (1.5.2)
     rack-test (0.6.2)
@@ -100,6 +103,9 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
+    sawyer (0.5.4)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
     sdoc (0.4.0)
       json (~> 1.8)
       rdoc (~> 4.0, < 5.0)
@@ -142,6 +148,7 @@ DEPENDENCIES
   docker-api (= 1.9.0)
   faraday_middleware
   jbuilder (~> 2.0)
+  octokit (~> 3.0)
   rails (= 4.1.0)
   rspec-rails
   sdoc

--- a/lib/panamax_agent/configuration.rb
+++ b/lib/panamax_agent/configuration.rb
@@ -13,6 +13,7 @@ module PanamaxAgent
       :journal_api_url,
       :pmx_registry_api_url,
       :pmx_registry_api_version,
+      :github_access_token,
       :open_timeout,
       :read_timeout,
       :ssl_options,

--- a/lib/panamax_agent/github/client.rb
+++ b/lib/panamax_agent/github/client.rb
@@ -1,0 +1,33 @@
+require 'panamax_agent/client'
+require 'panamax_agent/github/client/repos'
+require 'panamax_agent/github/client/file'
+
+module PanamaxAgent
+  module Github
+    class Client < PanamaxAgent::Client
+
+      attr_reader :github_client
+
+      def initialize(options={})
+        super
+        @github_client = Octokit::Client.new(access_token: github_access_token)
+      end
+
+      def token_authenticated?
+        @github_client.token_authenticated?
+      end
+
+      def scopes
+        @github_client.scopes
+      end
+
+      def emails
+        @github_client.emails
+      end
+
+      include PanamaxAgent::Github::Client::Repos
+      include PanamaxAgent::Github::Client::File
+
+    end
+  end
+end

--- a/lib/panamax_agent/github/client/file.rb
+++ b/lib/panamax_agent/github/client/file.rb
@@ -1,0 +1,37 @@
+module PanamaxAgent
+  module Github
+    class Client < PanamaxAgent::Client
+      module File
+
+        def create_file(repo, file_path, commit_message, file_object_for_content, branch=nil)
+          opts = { file: file_object_for_content }
+          opts[:branch] = branch if branch
+          github_client.create_contents(repo, file_path, commit_message, nil, opts)
+        end
+
+        def get_file(repo, file_path, branch=nil)
+          opts = { path: file_path }
+          opts[:ref] = branch if branch
+          github_client.contents(repo, opts)
+        end
+
+        def delete_file(repo, file_path, commit_message, branch=nil)
+          resp = get_file(repo, file_path, branch)
+          file_sha = resp.sha
+          opts = {}
+          opts[:branch] = branch if branch
+          github_client.delete_contents(repo, file_path, commit_message, file_sha, opts)
+        end
+
+        def update_file(repo, file_path, commit_message, file_object_for_content, branch=nil)
+          resp = get_file(repo, file_path, branch)
+          file_sha = resp.sha
+          opts = { file: file_object_for_content }
+          opts[:branch] = branch if branch
+          github_client.update_contents(repo, file_path, commit_message, file_sha, nil, opts)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/panamax_agent/github/client/repos.rb
+++ b/lib/panamax_agent/github/client/repos.rb
@@ -1,0 +1,17 @@
+module PanamaxAgent
+  module Github
+    class Client < PanamaxAgent::Client
+      module Repos
+
+        def list_repos
+          github_client.repos
+        end
+
+        def get_repo(repo)
+          github_client.repo(repo)
+        end
+
+      end
+    end
+  end
+end

--- a/spec/lib/panamax_agent/github/client/file_spec.rb
+++ b/spec/lib/panamax_agent/github/client/file_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe PanamaxAgent::Github::Client::Repos do
+  let(:fake_github_client) { double(:fake_github_client) }
+  subject { PanamaxAgent::Github::Client.new(github_client: fake_github_client) }
+
+  let(:repo_name)   { 'foo/bar' }
+  let(:file_path)   { 'my_file.txt' }
+  let(:commit_msg)  { 'Some commit message.' }
+  let(:file)        { fixture_data('foo.txt') }
+  let(:response)    { double(:response, sha: '123123sdfsf234234') }
+
+  before do
+    Octokit::Client.stub(:new).and_return(fake_github_client)
+    fake_github_client.stub(:contents).and_return(response)
+  end
+
+  describe '#create_file' do
+
+    it 'create a file' do
+      expect(fake_github_client).to receive(:create_contents)
+                                    .with(repo_name, file_path, commit_msg, nil, file: file)
+                                    .and_return(response)
+
+      subject.create_file(repo_name, file_path, commit_msg, file)
+    end
+  end
+
+  describe '#get_file' do
+
+    it 'get a file' do
+      expect(fake_github_client).to receive(:contents)
+                                    .with(repo_name, path: file_path)
+                                    .and_return(response)
+
+      subject.get_file(repo_name, file_path)
+    end
+  end
+
+  describe '#update_file' do
+
+    it 'update a file' do
+      expect(fake_github_client).to receive(:update_contents)
+                                    .with(repo_name, file_path, commit_msg, response.sha, nil, file: file)
+                                    .and_return(response)
+      subject.update_file(repo_name, file_path, commit_msg, file)
+    end
+  end
+
+  describe '#delete_file' do
+
+    it 'delete a file' do
+      expect(fake_github_client).to receive(:delete_contents)
+                                    .with(repo_name, file_path, commit_msg, response.sha, {})
+                                    .and_return(response)
+      subject.delete_file(repo_name, file_path, commit_msg)
+    end
+  end
+
+end

--- a/spec/lib/panamax_agent/github/client/repos_spec.rb
+++ b/spec/lib/panamax_agent/github/client/repos_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe PanamaxAgent::Github::Client::Repos do
+  let(:fake_github_client) { double(:fake_github_client) }
+  subject { PanamaxAgent::Github::Client.new(github_client: fake_github_client) }
+
+  let(:repo_name) { 'foo/bar' }
+  let(:response) { double(:response) }
+
+  before do
+    Octokit::Client.stub(:new).and_return(fake_github_client)
+    fake_github_client.stub(:repos).and_return(response)
+  end
+
+  describe '#list_repos' do
+
+    it 'returns the repos' do
+      expect(fake_github_client).to receive(:repos)
+                                    .and_return(response)
+
+      subject.list_repos
+    end
+  end
+
+  describe '#get_repo' do
+
+    it 'returns the repo' do
+      expect(fake_github_client).to receive(:repo)
+                                    .with(repo_name)
+                                    .and_return(response)
+
+      subject.get_repo(repo_name)
+    end
+  end
+
+end

--- a/spec/support/fixtures/foo.txt
+++ b/spec/support/fixtures/foo.txt
@@ -1,0 +1,1 @@
+Just a file with some random contents.


### PR DESCRIPTION
Fixes [#71760404].

Manage files on a public/private repo based on an user's github access via access tokens with appropriate rights.

gc = PanamaxAgent::Github::Client.new(:github_access_token => '<your access token>')
gc.create_file('rupakg/pmxtest', 'from_api.txt', 'Via api', File.open('/var/app/path/test.txt') )
gc.get_file('rupakg/pmxtest', 'from_api.txt')
gc.update_file('rupakg/pmxtest', 'from_api.txt', 'Updated via api', File.open('/var/app/path/test_2.txt') )
gc.delete_file('rupakg/pmxtest', 'from_api.txt', 'Deleted via api' )
