### PR TITLE
Separate serializers for AppCategory/ServiceCategory

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,16 +2,16 @@ class CategoriesController < ApplicationController
   respond_to :json
 
   def index
-    respond_with app.categories, each_serializer: CategorySerializer
+    respond_with app.categories
   end
 
   def show
-    respond_with app.categories.find(params[:id]), serializer: CategorySerializer
+    respond_with app.categories.find(params[:id])
   end
 
   def create
     category = app.categories.create(category_params)
-    respond_with app, category, serializer: CategorySerializer
+    respond_with app, category
   end
 
   def update

--- a/app/serializers/app_category_serializer.rb
+++ b/app/serializers/app_category_serializer.rb
@@ -1,4 +1,4 @@
-class CategorySerializer < ActiveModel::Serializer
+class AppCategorySerializer < ActiveModel::Serializer
   self.root = false
 
   attributes :id, :name, :position

--- a/app/serializers/app_serializer.rb
+++ b/app/serializers/app_serializer.rb
@@ -3,7 +3,7 @@ class AppSerializer < ActiveModel::Serializer
 
   attributes :id, :name, :from, :errors, :documentation
 
-  has_many :categories, serializer: CategorySerializer
+  has_many :categories, serializer: AppCategorySerializer
   has_many :services, serializer: ServiceLiteSerializer
 
   def errors

--- a/app/serializers/service_category_serializer.rb
+++ b/app/serializers/service_category_serializer.rb
@@ -1,0 +1,9 @@
+class ServiceCategorySerializer < ActiveModel::Serializer
+  self.root = false
+
+  attributes :id, :name, :position
+
+  def id
+    object.app_category_id
+  end
+end

--- a/app/serializers/service_lite_serializer.rb
+++ b/app/serializers/service_lite_serializer.rb
@@ -7,5 +7,5 @@ class ServiceLiteSerializer < ActiveModel::Serializer
     object.errors if object.errors.present?
   end
 
-  has_many :categories, serializer: CategorySerializer
+  has_many :categories, serializer: ServiceCategorySerializer
 end

--- a/app/serializers/service_serializer.rb
+++ b/app/serializers/service_serializer.rb
@@ -6,7 +6,7 @@ class ServiceSerializer < ActiveModel::Serializer
 
   has_one :app, serializer: AppLiteSerializer
 
-  has_many :categories, serializer: CategorySerializer
+  has_many :categories, serializer: ServiceCategorySerializer
 
   has_many :links, serializer: ServiceLinkSerializer
 

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -11,7 +11,7 @@ describe CategoriesController do
 
       expected = ActiveModel::ArraySerializer.new(
         [app_categories(:category1)],
-        each_serializer: CategorySerializer).to_json
+        each_serializer: AppCategorySerializer).to_json
 
       expect(response.body).to eq expected
     end
@@ -24,7 +24,7 @@ describe CategoriesController do
     it 'returns the specified app category' do
       get :show, { app_id: app, id: category, format: :json }
 
-      expect(response.body).to eq CategorySerializer.new(category).to_json
+      expect(response.body).to eq AppCategorySerializer.new(category).to_json
     end
   end
 
@@ -47,7 +47,7 @@ describe CategoriesController do
 
     it 'returns the category' do
       post :create, params.merge({ app_id: app, format: :json })
-      expect(response.body).to eq CategorySerializer.new(AppCategory.last).to_json
+      expect(response.body).to eq AppCategorySerializer.new(AppCategory.last).to_json
     end
 
     it 'returns a 201 status code' do

--- a/spec/serializers/app_category_serializer_spec.rb
+++ b/spec/serializers/app_category_serializer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CategorySerializer do
+describe AppCategorySerializer do
   let(:category_model) { AppCategory.new }
 
   it 'exposes the attributes to be jsonified' do

--- a/spec/serializers/service_category_serializer_spec.rb
+++ b/spec/serializers/service_category_serializer_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe ServiceCategorySerializer do
+  let(:service_category) { ServiceCategory.new }
+  let(:app_category) { AppCategory.new }
+
+  before { service_category.app_category = app_category }
+
+  it 'exposes the attributes to be jsonified' do
+    serialized = described_class.new(service_category).as_json
+    expected_keys = [
+      :id,
+      :name,
+      :position
+    ]
+    expect(serialized.keys).to match_array expected_keys
+  end
+end


### PR DESCRIPTION
The AppCategory and ServiceCategory need to be serialized differently to ensure that we're returning the correct data in each case. This commit introduces ServiceCategorySerializer and renames CategorySerializer to AppCategorySerializer to ensure that the correct serializers are invoked in the appropriate situations.

[#72305482]
