### PR TITLE
Switch seeds to use string keys in hashes

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -67,8 +67,8 @@ class Service < ActiveRecord::Base
 
   def copy_links_from_image(image, services)
     image.links.each do |link|
-      linked_to_service = services.find { |service| service.name == link[:service] }
-      self.links << ServiceLink.new(linked_to_service: linked_to_service, alias: link[:alias])
+      linked_to_service = services.find { |service| service.name == link['service'] }
+      self.links << ServiceLink.new(linked_to_service: linked_to_service, alias: link['alias'])
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,7 @@ unless Template.where(name: 'Wordpress').present?
     description: 'MySQL',
     expose: [3306],
     environment: { 'MYSQL_ROOT_PASSWORD' => 'pass@word01'},
-    ports: [{host_port: 3306, container_port: 3306}],
+    ports: [{'host_port' => 3306, 'container_port' => 3306}],
     categories: [db_cat],
     icon: 'http://panamax.ca.tier3.io/service_icons/icon_service_db_grey.png'
   )
@@ -38,8 +38,8 @@ unless Template.where(name: 'Wordpress').present?
       repository: 'panamax/panamax-docker-wordpress',
       tag: 'latest',
       description: 'Wordpress',
-      links: [{service: 'DB_1', alias:'DB_1'}],
-      ports: [{host_port: 8080, container_port: 80}],
+      links: [{'service' => 'DB_1', 'alias' => 'DB_1'}],
+      ports: [{'host_port' => 8080, 'container_port' => 80}],
       expose: [80],
       environment: { 'DB_PASSWORD' => 'pass@word01' },
       categories: [web_cat],
@@ -68,8 +68,8 @@ unless Template.where(name: 'Rails').present?
     repository: 'dharmamike/dc-rails',
     tag: 'latest',
     description: 'welcome to rails',
-    links: [{service: 'DB_2', alias:'DB_1'}],
-    ports: [{host_port: 8088, container_port: 3000}],
+    links: [{'service' => 'DB_2', 'alias' =>'DB_1'}],
+    ports: [{'host_port' => 8088, 'container_port' => 3000}],
     icon: 'http://panamax.ca.tier3.io/service_icons/icon_service_docker_grey.png'
 
   )

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -110,7 +110,7 @@ describe App do
     context 'with linked images' do
 
       before do
-        i1 = Image.create(name: 'WP', links: [{ service: 'MYSQL', alias: 'DB' }])
+        i1 = Image.create(name: 'WP', links: [{ 'service' => 'MYSQL', 'alias' => 'DB' }])
         i2 = Image.create(name: 'MYSQL')
         template.images = [i1, i2]
       end


### PR DESCRIPTION
In our seeds file we have been using symbol keys in the hashes, but when we are loading templates from JSON all of the keys will be strings. Need to change the seeds to better reflect real-world data.

We had some places in our code where we were assuming symbol keys and others where we were assuming string keys. Updated code to expect string keys for everything.

Signed-off-by: Alex Welch me@alexwelch.com
