### PR TITLE
Continuation of symbol-to-string conversion

### DIFF
--- a/app/models/concerns/docker_runnable.rb
+++ b/app/models/concerns/docker_runnable.rb
@@ -27,13 +27,13 @@ module DockerRunnable
     return unless ports
     ports.map do |port|
       option = '-p '
-      if port[:host_interface] || port[:host_port]
-        option << "#{port[:host_interface]}:" if port[:host_interface]
-        option << "#{port[:host_port]}" if port[:host_port]
+      if port['host_interface'] || port['host_port']
+        option << "#{port['host_interface']}:" if port['host_interface']
+        option << "#{port['host_port']}" if port['host_port']
         option << ':'
       end
-      option << "#{port[:container_port]}"
-      option << "/#{port[:proto]}" if port[:proto]
+      option << "#{port['container_port']}"
+      option << "/#{port['proto']}" if port['proto']
       option
     end
   end
@@ -51,7 +51,7 @@ module DockerRunnable
   def volume_flags
     return unless volumes
     volumes.map do |volume|
-      "-v #{volume[:host_path]}:#{volume[:container_path]}"
+      "-v #{volume['host_path']}:#{volume['container_path']}"
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -60,7 +60,7 @@ unless Template.where(name: 'Rails').present?
       repository: 'dharmamike/dc-pgsql',
       tag: 'latest',
       description: 'PostgreSQL',
-      ports: [{host_port: 5432, container_port: 5432}],
+      ports: [{ 'host_port' => 5432, 'container_port' => 5432 }],
       icon: 'http://panamax.ca.tier3.io/service_icons/icon_service_db_grey.png'
   )
   rails.images.create(

--- a/spec/support/shared/docker_runnable_example.rb
+++ b/spec/support/shared/docker_runnable_example.rb
@@ -32,10 +32,10 @@ shared_examples 'a docker runnable model' do
 
     before do
       model.ports = [{
-        host_interface: '0.0.0.0',
-        host_port: '8000',
-        container_port: '3000',
-        proto: 'tcp'
+        'host_interface' => '0.0.0.0',
+        'host_port' => '8000',
+        'container_port' => '3000',
+        'proto' => 'tcp'
       }]
     end
 
@@ -72,7 +72,7 @@ shared_examples 'a docker runnable model' do
   context 'when volumes are specified' do
 
     before do
-      model.volumes = [{ host_path: '/tmp/foo', container_path: '/tmp/bar' }]
+      model.volumes = [{ 'host_path' => '/tmp/foo', 'container_path' => '/tmp/bar' }]
     end
 
     it 'generates a docker command with -v' do


### PR DESCRIPTION
Continuing the switch of hash keys to use strings instead of symbols in the serialized service attributes.

This really should have been handled as part of https://github.com/CenturyLinkLabs/panamax-api/pull/90
