### PR TITLE
Return email and access_token status in User#show

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,9 @@
 class UserSerializer < ActiveModel::Serializer
   self.root = false
 
-  attributes :repos
+  attributes :email, :repos, :github_access_token_present?
+
+  def github_access_token_present?
+    object.github_access_token.present?
+  end
 end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -9,7 +9,7 @@ describe UserSerializer do
 
   it 'exposes the attributes to be jsonified' do
     serialized = described_class.new(user_model).as_json
-    expected_keys = [:repos]
+    expected_keys = [:email, :repos, :github_access_token_present]
     expect(serialized.keys).to match_array expected_keys
   end
 end


### PR DESCRIPTION
Not that we're not yet pulling the email address from GitHub, but this will at least return it (along w/ the new `github_access_token_present` flag) in the User#show action

[#72483498]
