### PR TITLE
Add capability to return usage metrics from the api.

### DIFF
--- a/lib/panamax_agent/configuration.rb
+++ b/lib/panamax_agent/configuration.rb
@@ -13,6 +13,7 @@ module PanamaxAgent
       :journal_api_url,
       :pmx_registry_api_url,
       :pmx_registry_api_version,
+      :pmx_metrics_location,
       :open_timeout,
       :read_timeout,
       :ssl_options,
@@ -28,6 +29,7 @@ module PanamaxAgent
     DEFAULT_JOURNAL_API_URL = ENV['JOURNAL_ENDPOINT']
     DEFAULT_PMX_REGISTRY_API_URL = 'http://74.201.240.198:5000'
     DEFAULT_PMX_REGISTRY_API_VERSION = 'v1'
+    DEFAULT_PMX_METRICS_LOCATION = ENV['PANAMAX_METRICS_LOCATION']
     DEFAULT_OPEN_TIMEOUT = 2
     DEFAULT_READ_TIMEOUT = 5
     DEFAULT_SSL_OPTIONS = { verify: false }
@@ -53,6 +55,7 @@ module PanamaxAgent
       self.journal_api_url = DEFAULT_JOURNAL_API_URL
       self.pmx_registry_api_url = DEFAULT_PMX_REGISTRY_API_URL
       self.pmx_registry_api_version = DEFAULT_PMX_REGISTRY_API_VERSION
+      self.pmx_metrics_location = DEFAULT_PMX_METRICS_LOCATION
       self.open_timeout = DEFAULT_OPEN_TIMEOUT
       self.read_timeout = DEFAULT_READ_TIMEOUT
       self.ssl_options = DEFAULT_SSL_OPTIONS

--- a/lib/panamax_agent/panamax/client.rb
+++ b/lib/panamax_agent/panamax/client.rb
@@ -1,9 +1,12 @@
 require 'panamax_agent/client'
 require 'panamax_agent/panamax/client/components'
+require 'panamax_agent/panamax/client/host_metrics'
 
 module PanamaxAgent
   module Panamax
     class Client < PanamaxAgent::Client
+
+      PANAMAX_METRICS_PATH = '/keys/_panamax'
 
       attr_reader :registry_client
 
@@ -12,9 +15,19 @@ module PanamaxAgent
         @registry_client = PanamaxAgent::Registry::Client.new(
           registry_api_url: pmx_registry_api_url,
           registry_api_version: pmx_registry_api_version)
+
+        @metrics_path = etcd_api_version + PANAMAX_METRICS_PATH
       end
 
+      include PanamaxAgent::Panamax::Connection
       include PanamaxAgent::Panamax::Client::Components
+      include PanamaxAgent::Panamax::Client::HostMetrics
+
+      protected
+
+      def resource_path(resource, *parts)
+        parts.unshift(resource).unshift(@metrics_path).join('/')
+      end
 
     end
   end

--- a/lib/panamax_agent/panamax/client/host_metrics.rb
+++ b/lib/panamax_agent/panamax/client/host_metrics.rb
@@ -1,0 +1,34 @@
+require 'panamax_agent/error'
+
+module PanamaxAgent
+  module Panamax
+    class Client < PanamaxAgent::Client
+      module HostMetrics
+
+        HOST_METRICS_RESOURCE = 'host/metrics'
+
+        def list_host_metrics
+          metrics = {}
+          begin
+            metrics_data = get_host_metrics
+          rescue PanamaxAgent::NotFound
+          end
+
+          metrics = JSON.parse(metrics_data['node']['value']) if metrics_data
+
+          { 'host_metrics' => metrics }
+        end
+
+        private
+
+        def get_host_metrics
+          get(host_metrics_path)
+        end
+
+        def host_metrics_path(*parts)
+          resource_path(HOST_METRICS_RESOURCE, *parts)
+        end
+      end
+    end
+  end
+end

--- a/lib/panamax_agent/panamax/connection.rb
+++ b/lib/panamax_agent/panamax/connection.rb
@@ -1,0 +1,29 @@
+require 'faraday'
+require 'panamax_agent/middleware/response/raise_error'
+
+module PanamaxAgent
+  module Panamax
+    module Connection
+
+      def connection
+        Faraday.new(connection_options) do |faraday|
+          faraday.request :url_encoded
+          faraday.response :json
+          faraday.response :raise_error
+          faraday.adapter adapter
+        end
+      end
+
+      private
+
+      def connection_options
+        {
+          url: etcd_api_url,
+          ssl: ssl_options,
+          proxy: proxy
+        }
+      end
+
+    end
+  end
+end

--- a/spec/lib/panamax_agent/configuration_spec.rb
+++ b/spec/lib/panamax_agent/configuration_spec.rb
@@ -17,6 +17,7 @@ describe PanamaxAgent::Configuration do
     its(:etcd_api_url) { should eql PanamaxAgent::Configuration::DEFAULT_ETCD_API_URL }
     its(:etcd_api_version) { should eql PanamaxAgent::Configuration::DEFAULT_ETCD_API_VERSION }
     its(:journal_api_url) { should eql PanamaxAgent::Configuration::DEFAULT_JOURNAL_API_URL }
+    its(:pmx_metrics_location) { should eql PanamaxAgent::Configuration::DEFAULT_PMX_METRICS_LOCATION }
     its(:open_timeout) { should eql PanamaxAgent::Configuration::DEFAULT_OPEN_TIMEOUT }
     its(:read_timeout) { should eql PanamaxAgent::Configuration::DEFAULT_READ_TIMEOUT }
     its(:logger) { should eql PanamaxAgent::Configuration::DEFAULT_LOGGER }

--- a/spec/lib/panamax_agent/panamax/client/host_metrics_spec.rb
+++ b/spec/lib/panamax_agent/panamax/client/host_metrics_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe PanamaxAgent::Panamax::Client::HostMetrics do
+
+  subject { PanamaxAgent::Panamax::Client.new }
+
+  let(:metrics_response) do
+    { 'node' =>
+      { 'value' => '{
+        "load_average":"0.00",
+        "cpu_idle":"90.9",
+        "memory_free":"146.514",
+        "cpu_cores":"2",
+        "last_updated":"2014/06/04 02:12:51" }'
+      }
+    }
+  end
+  let(:metrics_data) do
+    { 'host_metrics' =>
+      {
+        'load_average' => '0.00',
+        'cpu_idle' => '90.9',
+        'memory_free' => '146.514',
+        'cpu_cores' => '2',
+        'last_updated' => '2014/06/04 02:12:51'
+      }
+    }
+  end
+
+  describe '#list_host_metrics' do
+
+    before do
+      subject.stub(get: metrics_response)
+    end
+
+    it 'GETs the host metrics raw response' do
+      expect(subject).to receive(:get)
+                         .with('v2/keys/_panamax/host/metrics')
+                         .and_return(metrics_response)
+
+      subject.send(:get_host_metrics)
+    end
+
+    it 'returns the metrics meta' do
+      expect(subject.list_host_metrics).to eql(metrics_data)
+    end
+
+    context 'when #get_host_metrics raises NotFound' do
+      before do
+        subject.stub(:get_host_metrics)
+               .and_raise(PanamaxAgent::NotFound.new('boom'))
+      end
+
+      it 'return no metrics' do
+        expect(subject.list_host_metrics).to eql('host_metrics' => {})
+      end
+
+    end
+
+  end
+end

--- a/spec/lib/panamax_agent/panamax/connection_spec.rb
+++ b/spec/lib/panamax_agent/panamax/connection_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe PanamaxAgent::Panamax::Connection do
+
+  describe 'registered middleware' do
+
+    subject { PanamaxAgent::Panamax::Client.new.connection }
+
+    handlers = [
+      Faraday::Request::UrlEncoded,
+      FaradayMiddleware::ParseJson,
+      PanamaxAgent::Response::RaiseError,
+      Faraday::Adapter::NetHttp
+    ]
+
+    handlers.each do |handler|
+      it { expect(subject.builder.handlers).to include handler }
+    end
+
+    it "includes exactly #{handlers.count} handlers" do
+      expect(subject.builder.handlers.count).to eql handlers.count
+    end
+
+  end
+end


### PR DESCRIPTION
Finishes [#72297860].

There are some pre-requisites to test this:
1. @cakkineni added a systemd service that would collect host usage metrics and add it to etcd under a hidden key: "/_panamax/host/metrics". 
2. For testing purposes, one could manually add sample metrics data into etcd:

```
etcdctl set /_panamax/host/metrics '{"load_average":"0.00", "cpu_idle": "90.9", "memory_free":"146.514", "cpu_cores":"2", "last_updated":"2014/06/04 02:12:51"}'
```
1. The PR adds an API to retrieve the metrics data and expose it.
