### PR TITLE
Fix nil category issue when hydrating images from JSON

### DIFF
--- a/app/builders/template_builder/from_json.rb
+++ b/app/builders/template_builder/from_json.rb
@@ -18,7 +18,7 @@ module TemplateBuilder
 
     def create_images(images_hash)
       images_hash.map do |image_hash|
-        image_hash['categories'] = [image_hash.delete('category')]
+        image_hash['categories'] = Array(image_hash.delete('category'))
         Image.new(image_hash)
       end
     end


### PR DESCRIPTION
This prevents us from ending-up with something like

```
irb(main):012:0> Template.first.images.first.categories
=> [nil]
```

Using `Array()` will force this to be an empty array `[]` instead of an array of nil `[nil]`
