### PR TITLE
Limit journal output to 10,000 lines when no cursor is provided

### DIFF
--- a/lib/panamax_agent/journal/client.rb
+++ b/lib/panamax_agent/journal/client.rb
@@ -25,6 +25,11 @@ module PanamaxAgent
 
       def list_journal_entries(services, cursor=nil)
         services = [*services]
+
+        # If there is no cursor supplied, never retrieve more than
+        # 10,000 entries
+        cursor = ':-10000:' if cursor.nil? || cursor.empty?
+
         journal_lines = get_entries_by_fields({}, cursor)
 
         journal_lines.select do |journal_line|

--- a/spec/lib/panamax_agent/journal/client_spec.rb
+++ b/spec/lib/panamax_agent/journal/client_spec.rb
@@ -34,6 +34,22 @@ describe PanamaxAgent::Journal::Client do
       subject.list_journal_entries(services, cursor)
     end
 
+    context 'when no cursor is provided' do
+
+      it 'defaults the cursor to the last 10,000 entries' do
+        expect(subject).to receive(:get_entries_by_fields).with({}, ':-10000:')
+        subject.list_journal_entries(services, nil)
+      end
+    end
+
+    context 'when the cursor is an empty string' do
+
+      it 'defaults the cursor to the last 10,000 entries' do
+        expect(subject).to receive(:get_entries_by_fields).with({}, ':-10000:')
+        subject.list_journal_entries(services, '')
+      end
+    end
+
     context 'when a single service argument is provided' do
 
       let(:services) { 'foo.service' }


### PR DESCRIPTION
If the CoreOS host is left running for a long time, the journal can grow to be may hundreds of thousands of lines long. If we pull all this content into the API layer we're almost certainly going to crash it.

This change ensures that we never pull more than 10,000 lines at a time.

[#73238218]
