### PR TITLE
reworking the template-image association

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -13,7 +13,7 @@ class Image < ActiveRecord::Base
   serialize :environment, Hash
   serialize :volumes, Array
 
-  has_and_belongs_to_many :templates
+  belongs_to :template
 
   validates_presence_of :name
   validates_presence_of :repository

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,7 +1,7 @@
 class Template < ActiveRecord::Base
   include TemplateGithub
 
-  has_and_belongs_to_many :images
+  has_many :images
 
   serialize :authors, Array
 

--- a/db/migrate/20140326201625_create_templates.rb
+++ b/db/migrate/20140326201625_create_templates.rb
@@ -30,6 +30,7 @@ class CreateTemplates < ActiveRecord::Migration
       t.text :expose
       t.text :environment
       t.text :volumes
+      t.integer :template_id
 
       t.timestamps
     end
@@ -37,9 +38,5 @@ class CreateTemplates < ActiveRecord::Migration
     add_index :images, :image_id, unique: true
     add_index :images, :repository
 
-    create_table :images_templates do |t|
-      t.belongs_to :template
-      t.belongs_to :image
-    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,17 +43,13 @@ ActiveRecord::Schema.define(version: 20140528192410) do
     t.text     "expose"
     t.text     "environment"
     t.text     "volumes"
+    t.integer  "template_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_index "images", ["image_id"], name: "index_images_on_image_id", unique: true
   add_index "images", ["repository"], name: "index_images_on_repository"
-
-  create_table "images_templates", force: true do |t|
-    t.integer "template_id"
-    t.integer "image_id"
-  end
 
   create_table "service_categories", force: true do |t|
     t.integer  "service_id"
@@ -119,7 +115,6 @@ ActiveRecord::Schema.define(version: 20140528192410) do
   add_index "templates", ["name"], name: "index_templates_on_name"
 
   create_table "users", force: true do |t|
-    t.string "email"
     t.string "github_access_token"
   end
 

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Image do
-  it { should have_and_belong_to_many(:templates) }
+  it { should belong_to(:template) }
   it { should respond_to :is_official }
   it { should respond_to :is_trusted }
   it { should respond_to :star_count }

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Template do
-  it { should have_and_belong_to_many(:images) }
+  it { should have_many(:images) }
   it { should validate_presence_of(:name) }
 
   describe '.search' do


### PR DESCRIPTION
Images really belong to Templates.  They are pretty specific to that Template, so the model we used early on of having an Image belong to many Templates isn't really what we do in practice.  This PR addresses that.  It facilitates validation of an Image's link to another Image within a Template definition.
