### PR TITLE
Skirt around unsafe query rule by explicitly setting nil to empty array.

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -91,6 +91,8 @@ class Service < ActiveRecord::Base
     attributes[:environment] ||= []
     attributes[:environment].map! { |var| var.to_hash }
 
+    attributes[:expose] ||= []
+
     self.update(attributes)
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -220,6 +220,23 @@ describe Service do
       end
     end
 
+    context 'when expose is provided' do
+
+      let(:attrs_with_expose) { attrs.merge(expose: ['9999']) }
+
+      it 'passes expose through to the update' do
+        expect(subject).to receive(:update).with(hash_including(attrs_with_expose))
+        subject.update_with_relationships(attrs_with_expose)
+      end
+    end
+
+    context 'when expose vars are not provided' do
+      it 'updates with an empty array' do
+        expect(subject).to receive(:update).with(hash_including(expose: []))
+        subject.update_with_relationships(attrs)
+      end
+    end
+
     context 'when environment vars are not provided' do
       it 'updates with an empty env variable hash' do
         expect(subject).to receive(:update).with(hash_including(environment: []))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/74402900
