### PR TITLE
Fix for template file serialization

### DIFF
--- a/app/serializers/template_file_serializer.rb
+++ b/app/serializers/template_file_serializer.rb
@@ -1,11 +1,38 @@
 class TemplateFileSerializer < ActiveModel::Serializer
+
+  class TemplateFileImageSerializer < ActiveModel::Serializer
+
+    attributes :name,
+      :source,
+      :category,
+      :type,
+      :expose,
+      :ports,
+      :links,
+      :environment,
+      :volumes,
+      :command
+
+    def category
+      object.categories.first unless object.categories.blank?
+    end
+
+    def attributes
+      super.tap do |attrs|
+        # Filter out any nil or empty values
+        attrs.delete_if { |_, value| value.nil? || value.empty? }
+      end
+    end
+  end
+
   self.root = false
 
-  attributes :name, :description, :keywords, :recommended, :type, :documentation
+  attributes :name, :description, :keywords, :type, :documentation
 
-  has_many :images
+  has_many :images, serializer: TemplateFileImageSerializer
 
   def to_yaml
     as_json.deep_stringify_keys.to_yaml
   end
+
 end

--- a/spec/serializers/template_file_serializer_spec.rb
+++ b/spec/serializers/template_file_serializer_spec.rb
@@ -9,7 +9,6 @@ describe TemplateFileSerializer do
       :name,
       :description,
       :keywords,
-      :recommended,
       :type,
       :documentation,
       :images
@@ -20,13 +19,23 @@ describe TemplateFileSerializer do
   describe '#to_yaml' do
 
     let(:template_model) do
+
       Template.new(
         name: 'foo',
         description: 'bar',
         keywords: 'fizz, bin',
-        recommended: true,
         type: 'wordpress',
-        documentation: "This\n\is\nthe\ndocumentation"
+        documentation: "This\n\is\nthe\ndocumentation",
+        images: [
+          Image.new(
+            name: 'abc',
+            source: 'def',
+            type: 'ghi',
+            categories: ['jkl'],
+            expose: [8000],
+            environment: [{ 'variable' => 'mno', 'value' => 'pqr' }]
+          )
+        ]
       )
     end
 
@@ -38,14 +47,22 @@ describe TemplateFileSerializer do
 name: foo
 description: bar
 keywords: fizz, bin
-recommended: true
 type: wordpress
 documentation: |-
   This
   is
   the
   documentation
-images: []
+images:
+- name: abc
+  source: def
+  category: jkl
+  type: ghi
+  expose:
+  - 8000
+  environment:
+  - variable: mno
+    value: pqr
       EXPECTED
     end
 


### PR DESCRIPTION
Since we have different requirements for serializing templates/images for the API and for PMX template files we need to completely isolate the Serializer implementations. I've added a `TemplateFileImageSerializer` that is used exclusively for serializing `Image` models for PMX template files.

[#75067386]
