### PR TITLE
Handle journal API connection errors

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -40,6 +40,8 @@ class AppsController < ApplicationController
 
   def journal
     respond_with App.find(params[:id]).journal(params[:cursor])
+  rescue PanamaxAgent::ConnectionError => ex
+    handle_exception(ex, :journal_connection_error)
   end
 
   def rebuild

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -31,6 +31,8 @@ class ServicesController < ApplicationController
 
   def journal
     respond_with app.services.find(params[:id]).journal(params[:cursor])
+  rescue PanamaxAgent::ConnectionError => ex
+    handle_exception(ex, :journal_connection_error)
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,3 +22,4 @@
 en:
   hello: "Hello world"
   fleet_connection_error: "Fleet or Etcd services are not responding"
+  journal_connection_error: "Journal API service is not responding"

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -168,6 +168,26 @@ describe AppsController do
       get :journal, id: app.id, format: :json
       expect(response.body).to eql fixture_data('journal')
     end
+
+    context 'when the journal API is not responding' do
+
+      before do
+        App.any_instance.stub(:journal)
+          .and_raise(PanamaxAgent::ConnectionError, 'oops')
+      end
+
+      it 'returns an HTTP 500 status code' do
+        get :journal, id: app.id, format: :json
+        expect(response.status).to eq 500
+      end
+
+      it 'returns the journal error message' do
+        get :journal, id: app.id, format: :json
+
+        expect(response.body).to eq(
+          { message: I18n.t(:journal_connection_error) }.to_json)
+      end
+    end
   end
 
   describe '#rebuild' do

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -164,6 +164,26 @@ describe ServicesController do
       get :journal, app_id: app.id, id: Service.first.id, format: :json
       expect(response.body).to eq fixture_data('journal')
     end
+
+    context 'when the journal API is not responding' do
+
+      before do
+        Service.any_instance.stub(:journal)
+          .and_raise(PanamaxAgent::ConnectionError, 'oops')
+      end
+
+      it 'returns an HTTP 500 status code' do
+        get :journal, app_id: app.id, id: Service.first.id, format: :json
+        expect(response.status).to eq 500
+      end
+
+      it 'returns the journal error message' do
+        get :journal, app_id: app.id, id: Service.first.id, format: :json
+
+        expect(response.body).to eq(
+          { message: I18n.t(:journal_connection_error) }.to_json)
+      end
+    end
   end
 
   describe '#create' do


### PR DESCRIPTION
Make sure that friendly error messages are returned if we detect that the journal API is not responding.

[#75220696]
