### PR TITLE
Clean TCP port mapping protocol for docker run

### DIFF
--- a/app/models/concerns/docker_runnable.rb
+++ b/app/models/concerns/docker_runnable.rb
@@ -40,7 +40,7 @@ module DockerRunnable
         option << ':'
       end
       option << "#{port['container_port']}"
-      option << "/#{port['proto']}" if port['proto']
+      option << '/udp' if port['proto'] && port['proto'].upcase == 'UDP'
       option
     end
   end

--- a/spec/support/shared/docker_runnable_example.rb
+++ b/spec/support/shared/docker_runnable_example.rb
@@ -36,13 +36,42 @@ shared_examples 'a docker runnable model' do
           'host_interface' => '0.0.0.0',
           'host_port' => '8000',
           'container_port' => '3000',
-          'proto' => 'tcp'
         }]
       end
 
       it 'generates a docker command with -p' do
-        expected = '-p 0.0.0.0:8000:3000/tcp'
+        expected = '-p 0.0.0.0:8000:3000'
         expect(model.docker_run_string).to include expected
+      end
+
+      context 'when the UDP protocol is specified' do
+
+        before do
+          model.ports = [{
+            'container_port' => '3000',
+            'proto' => 'udp',
+          }]
+        end
+
+        it 'generates a docker command with -p with the udp protocol' do
+          expected = '-p 3000/udp'
+          expect(model.docker_run_string).to include expected
+        end
+      end
+
+      context 'when the TCP protocol is specified' do
+
+        before do
+          model.ports = [{
+            'container_port' => '3000',
+            'proto' => 'tcp',
+          }]
+        end
+
+        it 'generates a docker command with -p with no protocol' do
+          expected = '-p 3000'
+          expect(model.docker_run_string).to include expected
+        end
       end
     end
 


### PR DESCRIPTION
The `docker run` command line accepts only `/udp` as a valid port mapping protocol -- the absence of an explicit protocol is interpreted to mean TCP. 

This code will look specifically for "UDP" in protocol field and pass that along to the `docker run` command -- any other protocol value will be filtered out (and treated as TCP)

[#75220546]
