### PR TITLE
Refactor RepositoryController

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -1,15 +1,11 @@
 class RepositoriesController < ApplicationController
 
-  def list_tags
-    repo = params[:repository]
-    if params[:local_image] == 'true'
-      image = LocalImage.find_by_name(repo)
-    else
-      image = RemoteImage.find_by_name(repo)
-    end
-    respond_with image.tags
+  def show
+    image = (params[:local] == 'true' ? LocalImage : RemoteImage)
+      .find_by_name(params[:id])
+
+    respond_with image, serializer: RepositorySerializer
   rescue PanamaxAgent::ConnectionError => ex
     handle_exception(ex, :registry_connection_error)
   end
-
 end

--- a/app/serializers/repository_serializer.rb
+++ b/app/serializers/repository_serializer.rb
@@ -1,0 +1,13 @@
+class RepositorySerializer < ActiveModel::Serializer
+  self.root = false
+
+  attributes :id, :tags
+
+  def id
+    object.id
+  end
+
+  def tags
+    object.tags
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 PanamaxApi::Application.routes.draw do
   get '/search', to: 'search#index'
 
-  get 'repositories/*repository/tags', to: 'repositories#list_tags'
+  get 'repositories/*id', to: 'repositories#show'
 
   resources :templates, only: [:index, :show, :create, :destroy] do
     member do

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -7,9 +7,10 @@ describe RepositoriesController do
     let(:repository) { 'name/repo' }
 
     let(:tags) { %w(tag1 tag2) }
-    let(:image) { double(:image, tags: tags) }
 
     context 'for a local image' do
+
+      let(:image) { LocalImage.new(id: repository, tags: tags) }
 
       before do
         LocalImage.stub(:find_by_name).and_return(image)
@@ -17,16 +18,18 @@ describe RepositoriesController do
 
       it 'finds the local image' do
         expect(LocalImage).to receive(:find_by_name).with(repository)
-        get :list_tags, repository: repository, local_image: 'true', format: :json
+        get :show, id: repository, local: 'true', format: :json
       end
 
       it 'returns the array of tag names' do
-        get :list_tags, repository: repository, local_image: 'true', format: :json
-        expect(response.body).to eql(tags.to_json)
+        get :show, id: repository, local: 'true', format: :json
+        expect(response.body).to eq RepositorySerializer.new(image).to_json
       end
     end
 
     context 'for a remote image' do
+
+      let(:image) { RemoteImage.new(id: repository, tags: tags) }
 
       before do
         RemoteImage.stub(:find_by_name).and_return(image)
@@ -34,12 +37,12 @@ describe RepositoriesController do
 
       it 'finds the remote image' do
         expect(RemoteImage).to receive(:find_by_name).with(repository)
-        get :list_tags, repository: repository, local_image: true, format: :json
+        get :show, id: repository, format: :json
       end
 
       it 'returns the array of tag names' do
-        get :list_tags, repository: repository, local_image: true, format: :json
-        expect(response.body).to eql(tags.to_json)
+        get :show, id: repository, format: :json
+        expect(response.body).to eq RepositorySerializer.new(image).to_json
       end
 
     end
@@ -52,7 +55,7 @@ describe RepositoriesController do
       end
 
       it 'returns the registry connection error message' do
-        get :list_tags, repository: repository, format: :json
+        get :show, id: repository, format: :json
 
         expect(response.status).to eq 500
         expect(response.body).to eq(

--- a/spec/routing/repositories_routes_spec.rb
+++ b/spec/routing/repositories_routes_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'repositories routes' do
+
+  it 'routes GET to the repositories controller show action' do
+    expect(get: '/repositories/foo/bar').to route_to(
+       controller: 'repositories',
+       action: 'show',
+       id: 'foo/bar'
+    )
+  end
+end

--- a/spec/serializers/repository_serializer_spec.rb
+++ b/spec/serializers/repository_serializer_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe RepositorySerializer do
+  let(:image_model) { LocalImage.new(id: 'foo') }
+
+  it 'exposes the attributes to be jsonified' do
+    serialized = described_class.new(image_model).as_json
+    expected = [:id, :tags]
+    expect(serialized.keys).to match_array expected
+  end
+end


### PR DESCRIPTION
This is a refactor of the `RepositoryController` to make it more ActiveResource-friendly.

First, instead of simply returning an array of tags for a given repository, the API will now return a representation of the repository itself.  Something like:

```
{
  "id": "ubuntu",
  "tags: [
    "latest",
    "10.04",
    "12.04"
  ]
}
```

Then, instead of using

```
GET /repositories/:repository/tags
```

as the endpoint, it's been changed to 

```
GET /repositories/:repository
```

Since what we're returning is a representation of a specific repository, this endpoint makes more sense.

Also, the flag for retrieving a local repository has been changed from `local_image` to simply `local`.

Required by: https://github.com/CenturyLinkLabs/panamax-ui/pull/233
