### PR TITLE
Hard-code GH access token for template loading

### DIFF
--- a/lib/github_access_token_override.rb
+++ b/lib/github_access_token_override.rb
@@ -1,0 +1,7 @@
+module GithubAccessTokenOverride
+  refine User do
+    def github_access_token
+      '4afd3519b925cd38bb1b04398de783266859ca47'
+    end
+  end
+end

--- a/lib/tasks/panamax.rake
+++ b/lib/tasks/panamax.rake
@@ -2,6 +2,7 @@ namespace :panamax do
   namespace :templates do
     desc 'Populate local template cache from all registered repositories'
     task :load => :environment do
+      using GithubAccessTokenOverride
       Template.load_templates_from_template_repos
     end
 

--- a/spec/lib/github_access_token_override_spec.rb
+++ b/spec/lib/github_access_token_override_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe GithubAccessTokenOverride do
+
+  using GithubAccessTokenOverride
+
+  subject { User.new }
+
+  describe '#github_access_token' do
+
+    it 'returns our hard-coded access token' do
+      expect(subject.github_access_token).to eq '4afd3519b925cd38bb1b04398de783266859ca47'
+    end
+  end
+end


### PR DESCRIPTION
This is a temporary fix until we find a work-around for the Git API limit issue. Until we get that figured out, we're going to hard-code our read-only GH access token into the rake task that does the template loading at start-up time.

[finishes #76023280]
