### PR TITLE
Return tags in local image search results

### DIFF
--- a/app/serializers/local_image_search_result_serializer.rb
+++ b/app/serializers/local_image_search_result_serializer.rb
@@ -1,10 +1,14 @@
 class LocalImageSearchResultSerializer < ActiveModel::Serializer
   self.root = false
 
-  attributes :source, :description, :is_official, :is_trusted, :star_count
+  attributes :source, :tags, :description, :is_official, :is_trusted, :star_count
 
   def source
     object.id
+  end
+
+  def tags
+    object.tags
   end
 
   def description

--- a/spec/serializers/local_image_search_result_serializer_spec.rb
+++ b/spec/serializers/local_image_search_result_serializer_spec.rb
@@ -5,7 +5,15 @@ describe LocalImageSearchResultSerializer do
 
   it 'exposes the attributes to be jsonified' do
     serialized = described_class.new(image_model).as_json
-    expected = [:source, :description, :is_official, :is_trusted, :star_count]
-    expect(serialized.keys).to match_array expected
+
+    expected_keys = [
+      :source,
+      :tags,
+      :description,
+      :is_official,
+      :is_trusted,
+      :star_count
+    ]
+    expect(serialized.keys).to match_array expected_keys
   end
 end


### PR DESCRIPTION
Since we don't have to do any extra work to retrieve tags for local images, we should return them as part of the search results.

On the UI side this will allow us to show tags for local images without having to do the on-demand AJAX load thing.

[finishes #76092384]
