### PR TITLE
Add virtual_size to LocalImage model

### DIFF
--- a/app/models/local_image.rb
+++ b/app/models/local_image.rb
@@ -2,12 +2,13 @@ class LocalImage
 
   UNTAGGED = '<none>'
 
-  attr_accessor :id, :tags
+  attr_accessor :id, :virtual_size, :tags
 
   # When using .all the ID is the same as the Docker image ID
   def self.all
     Docker::Image.all.map do |image|
       new(id: image.id,
+        virtual_size: image.info['VirtualSize'],
         tags: image.info['RepoTags'] || [UNTAGGED])
     end
   end
@@ -50,6 +51,7 @@ class LocalImage
 
   def initialize(options={})
     self.id = options[:id]
+    self.virtual_size = options[:virtual_size]
     self.tags = Array(options[:tags])
   end
 

--- a/spec/models/local_image_spec.rb
+++ b/spec/models/local_image_spec.rb
@@ -6,6 +6,7 @@ describe LocalImage do
     double(:local_image1,
       id: 'abc123',
       info: {
+        'VirtualSize' => 111,
         'RepoTags' => ['foo/bar:latest', 'foo/bar:1.0', 'fizz:latest']
       })
   end
@@ -13,13 +14,16 @@ describe LocalImage do
   let(:local_image2) do
     double(:local_image2,
       id: 'xyz789',
-      info: {})
+      info: {
+        'VirtualSize' => 222,
+      })
   end
 
   let(:local_image3) do
     double(:local_image3,
       id: 'efg456',
       info: {
+        'VirtualSize' => 333,
         'RepoTags' => ['panamax:latest']
       })
   end
@@ -30,6 +34,7 @@ describe LocalImage do
 
   describe 'attributes' do
     it { should respond_to :id }
+    it { should respond_to :virtual_size }
     it { should respond_to :tags }
   end
 
@@ -60,6 +65,7 @@ describe LocalImage do
 
       expect(result).to be_kind_of(described_class)
       expect(result.id).to eq local_image1.id
+      expect(result.virtual_size).to eq local_image1.info['VirtualSize']
       expect(result.tags).to eq local_image1.info['RepoTags']
     end
   end


### PR DESCRIPTION
Return a `virtual_size` as part of the data returned for local images.

[finishes #76163714]
