### PR TITLE
Fix for subscribe flag in Users controller

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,12 @@ class UsersController < ApplicationController
   end
 
   def update
+    params[:subscribe] =
+      params[:subscribe] == true ||
+      params[:subscribe] == 'true' ||
+      params[:subscribe] == 1 ||
+      params[:subscribe] == '1'
+
     user = User.instance
     user.update(user_params)
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -17,7 +17,7 @@ describe UsersController do
 
   describe '#update' do
 
-    let(:params) { { github_access_token: 'token', subscribe: true } }
+    let(:params) { { github_access_token: 'token', subscribe: '1' } }
 
     context 'when the user is successfully updated' do
 
@@ -40,10 +40,38 @@ describe UsersController do
         expect(response.status).to eq 204
       end
 
+      context 'when the subscribe flag is set to 1' do
+        it 'subscribes the user' do
+          expect_any_instance_of(User).to receive(:subscribe)
+          put :update, params.merge(subscribe: 1, format: :json)
+        end
+      end
+
+      context 'when the subscribe flag is set to "1"' do
+        it 'subscribes the user' do
+          expect_any_instance_of(User).to receive(:subscribe)
+          put :update, params.merge(subscribe: '1', format: :json)
+        end
+      end
+
       context 'when the subscribe flag is set to true' do
         it 'subscribes the user' do
           expect_any_instance_of(User).to receive(:subscribe)
-          put :update, params.merge(format: :json)
+          put :update, params.merge(subscribe: true, format: :json)
+        end
+      end
+
+      context 'when the subscribe flag is set to "true"' do
+        it 'subscribes the user' do
+          expect_any_instance_of(User).to receive(:subscribe)
+          put :update, params.merge(subscribe: 'true', format: :json)
+        end
+      end
+
+      context 'when the subscribe flag is set to "0"' do
+        it 'does NOT subscribe the user' do
+          expect_any_instance_of(User).to_not receive(:subscribe)
+          put :update, params.merge(subscribe: '0', format: :json)
         end
       end
 


### PR DESCRIPTION
Account for the fact that the `subscribe` flag is passed as a '1' or '0' and not a boolean.
