### PR TITLE
fleet template: add || true to some things that could normally fail

### DIFF
--- a/lib/panamax_agent/fleet/service_definition.rb
+++ b/lib/panamax_agent/fleet/service_definition.rb
@@ -96,8 +96,8 @@ module PanamaxAgent
         raw_string += "ExecStart=#{exec_start}\n" if exec_start
         raw_string += "ExecStartPost=#{exec_start_post}\n" if exec_start_post
         raw_string += "ExecReload=#{exec_reload}\n" if exec_reload
-        raw_string += "ExecStop=#{exec_stop}\n" if exec_stop
-        raw_string += "ExecStopPost=#{exec_stop_post}\n" if exec_stop_post
+        raw_string += "ExecStop=#{exec_stop} || true\n" if exec_stop
+        raw_string += "ExecStopPost=#{exec_stop_post} || true\n" if exec_stop_post
         raw_string += "Restart=#{restart}\n" if restart
         raw_string += "RestartSec=#{restart_sec}\n" if restart_sec
         raw_string += "TimeoutStartSec=#{timeout_start_sec}\n" if timeout_start_sec


### PR DESCRIPTION
Running Docker with --rm and an ExecStop docker rm will cause false failures of images. This has caused problems when I have been deploying a test application to my instance of Panamax. This fixes the problem by adding `|| true` to commands that _could_ normally return a non-0 exit code so that the web UI and other parts of Panamax do not get confused.
