### PR TITLE
Set auto_paginate for github requests.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ActiveRecord::Base
   end
 
   def github_client
-    @github_client ||= Octokit::Client.new(access_token: github_access_token)
+    @github_client ||= Octokit::Client.new(access_token: github_access_token, auto_paginate: true)
   end
 
   def mailchimp_client

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe User do
   let(:fake_gh_client) { double(:fake_gh_client) }
-
   before do
     Octokit::Client.stub(:new).and_return(fake_gh_client)
   end
@@ -128,6 +127,18 @@ describe User do
         expect(subject.repos).to eq []
       end
     end
+
+    context 'when github paging is set' do
+      before do
+        fake_gh_client.stub(:repos).and_return([])
+      end
+
+      it 'github client per page setting is set correctly' do
+        expect(Octokit::Client).to receive(:new).with(access_token: nil, auto_paginate: true)
+        subject.repos
+      end
+    end
+
   end
 
   describe '#email' do
@@ -224,4 +235,5 @@ describe User do
       end
     end
   end
+
 end


### PR DESCRIPTION
This resolves the bug of capping the no. of repos shown on the github repo dropdown on the save as template page at 30. This sets auto_paginate to set paging size to 100.
