### PR TITLE
Ignore errors from systemd ExecStop command

### DIFF
--- a/app/services/service_manager.rb
+++ b/app/services/service_manager.rb
@@ -62,7 +62,7 @@ class ServiceManager
       'ExecStartPre' => "-/usr/bin/docker pull #{service.from}",
       'ExecStart' => service.docker_run_string,
       'ExecStartPost' => docker_rm,
-      'ExecStop' => "/usr/bin/docker kill #{service.name}",
+      'ExecStop' => "-/usr/bin/docker kill #{service.name}",
       'ExecStopPost' => docker_rm,
       'Restart' => 'always',
       'RestartSec' => '10',

--- a/spec/services/service_manager_spec.rb
+++ b/spec/services/service_manager_spec.rb
@@ -101,7 +101,7 @@ describe ServiceManager do
               'ExecStartPre' => "-/usr/bin/docker pull #{image_name}",
               'ExecStart' => docker_run_string,
               'ExecStartPost' => "-/usr/bin/docker rm #{service_name}",
-              'ExecStop' => "/usr/bin/docker kill #{service_name}",
+              'ExecStop' => "-/usr/bin/docker kill #{service_name}",
               'ExecStopPost' => "-/usr/bin/docker rm #{service_name}",
               'Restart' => 'always',
               'RestartSec' => '10',


### PR DESCRIPTION
Will cut-down on unnecessary noise in the systemd journal
