### PR TITLE
add internal_name to service

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -29,6 +29,7 @@ class Service < ActiveRecord::Base
   serialize :volumes, Array
 
   before_save :resolve_name_conflicts
+  before_create :set_internal_name
   after_destroy :shutdown
 
   validates_presence_of :name
@@ -39,7 +40,7 @@ class Service < ActiveRecord::Base
   attr_writer :manager
 
   def unit_name
-    "#{name}.service"
+    "#{internal_name}.service"
   end
 
   def service_state
@@ -118,5 +119,9 @@ class Service < ActiveRecord::Base
   def resolve_name_conflicts
     sanitized_name = sanitize_name(name)
     self.name = increment_name(sanitized_name)
+  end
+
+  def set_internal_name
+    self.internal_name = self.name
   end
 end

--- a/db/migrate/20140910190904_add_internal_name_to_service.rb
+++ b/db/migrate/20140910190904_add_internal_name_to_service.rb
@@ -1,0 +1,15 @@
+class AddInternalNameToService < ActiveRecord::Migration
+
+  def up
+    add_column :services, :internal_name, :string
+
+    Service.all.each do |s|
+      s.update_attribute(:internal_name, s.name)
+    end
+  end
+
+  def down
+    remove_column :services, :internal_name
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140528192410) do
+ActiveRecord::Schema.define(version: 20140910190904) do
 
   create_table "app_categories", force: true do |t|
     t.string   "name"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 20140528192410) do
     t.text    "volumes"
     t.string  "type"
     t.integer "app_id"
+    t.string  "internal_name"
   end
 
   add_index "services", ["app_id"], name: "index_services_on_app_id"

--- a/spec/builders/app_builder/from_image_spec.rb
+++ b/spec/builders/app_builder/from_image_spec.rb
@@ -37,6 +37,7 @@ describe AppBuilder::FromImage do
       service = app.services.first
 
       expect(service.name).to eq options[:image]
+      expect(service.internal_name).to eq options[:image]
       expect(service.from).to eq options[:image]
     end
   end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -67,8 +67,8 @@ describe Service do
   it_behaves_like 'a classifiable model'
 
   describe '#unit_name' do
-    it 'postfixes the name with .service' do
-      subject.name = 'wordpress'
+    it 'postfixes the internal_name with .service' do
+      subject.internal_name = 'wordpress'
       expect(subject.unit_name).to eq 'wordpress.service'
     end
   end
@@ -76,6 +76,21 @@ describe Service do
   describe '#service_state' do
     it 'returns the service state from the service manager' do
       expect(subject.service_state).to eql(load_state: 'loaded')
+    end
+  end
+
+  describe 'before_create callback' do
+    describe '#internal_name' do
+      it 'is set to the service name' do
+        service = described_class.create(name: 'foobar')
+        expect(service.internal_name).to eq(service.name)
+      end
+
+      it 'does not change with subsequent updates to the service' do
+        service = described_class.create(name: 'foobar')
+        service.update(name: 'new_name')
+        expect(service.internal_name).to eq('foobar')
+      end
     end
   end
 
@@ -105,6 +120,7 @@ describe Service do
       end
 
     end
+
   end
 
   describe '#submit' do


### PR DESCRIPTION
We want users to be able to update service.name, but that value is used within the unit file. This introduces a new field on the service called 'internal_name' which is immutable and will be used in places where a string is used a unique identifier.

[finishes #70098068]
