### PR TITLE
Do not include colon if host_port has a value of ''

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Private repositories with port bug (#201)
-
+- -p flag bug in Docker run string (#208)
 
 0.2.0 - 2014-09-09
 ------------------

--- a/app/models/concerns/docker_runnable.rb
+++ b/app/models/concerns/docker_runnable.rb
@@ -36,8 +36,7 @@ module DockerRunnable
       option = '-p '
       if port['host_interface'] || port['host_port']
         option << "#{port['host_interface']}:" if port['host_interface']
-        option << "#{port['host_port']}" if port['host_port']
-        option << ':'
+        option << "#{port['host_port']}:" unless port['host_port'].to_s.empty?
       end
       option << "#{port['container_port']}"
       option << '/udp' if port['proto'] && port['proto'].upcase == 'UDP'

--- a/spec/support/shared/docker_runnable_example.rb
+++ b/spec/support/shared/docker_runnable_example.rb
@@ -44,6 +44,23 @@ shared_examples 'a docker runnable model' do
         expect(model.docker_run_string).to include expected
       end
 
+      context 'when the host_port is empty' do
+
+        before do
+          model.ports = [{
+                           'host_interface' => nil,
+                           'host_port' => '',
+                           'container_port' => '3000',
+                         }]
+        end
+
+        it 'does not include the colon affixed to the host port info' do
+          expected = '-p 3000'
+          expect(model.docker_run_string).to include expected
+        end
+      end
+
+
       context 'when the UDP protocol is specified' do
 
         before do


### PR DESCRIPTION
[fixes #79313728]

A little extra insurance in case a human chooses to pass an empty value of port['host_port']. Docker will only dynamically assign a port when the run string is formed as '-p 3000' and not '-p :3000'

Also updating the UI to not pass host_port if the user leaves it empty.
