### PR TITLE
Return ports exposed by the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+Latest
+------------------
+
+### Added
+- Return ports exposed by the Dockerfile in service details (#209)
+
+
 0.2.2 - 2014-09-26
 ------------------
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -65,6 +65,13 @@ class Service < ActiveRecord::Base
     self.start
   end
 
+  def default_exposed_ports
+    result = Docker::Image.get(self.from).info['Config']['ExposedPorts']
+    result.present? ? result.keys : []
+  rescue Docker::Error::DockerError
+    []
+  end
+
   # Works just like ActiveRecord::Persistence#update but will also update relations
   def update_with_relationships(attributes)
     attributes[:links] ||= []

--- a/app/serializers/service_serializer.rb
+++ b/app/serializers/service_serializer.rb
@@ -1,7 +1,7 @@
 class ServiceSerializer < ActiveModel::Serializer
   self.root = false
 
-  attributes :id, :name, :description, :from, :ports, :expose, :environment,
+  attributes :id, :name, :description, :from, :ports, :expose, :default_exposed_ports, :environment,
     :volumes, :command, :load_state, :active_state, :sub_state, :type, :errors,
     :docker_status
 

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -3,6 +3,19 @@ require 'spec_helper'
 describe ServicesController do
   let(:app) { App.first }
 
+  let(:image_status) do
+    double(:image_status,
+           info: {
+             'Config' => {
+               'ExposedPorts' => {'3000/tcp' => {} }
+             }
+           })
+  end
+
+  before do
+    Docker::Image.stub(:get).and_return(image_status)
+  end
+
   describe '#index' do
 
     it 'returns an array' do

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -172,6 +172,78 @@ describe Service do
     end
   end
 
+  describe '#default_exposed_ports' do
+
+    context 'when default exposed ports exist' do
+
+      let(:image_status) do
+        double(:image_status,
+               info: {
+                 'Config' => {
+                   'ExposedPorts' => {'3000/tcp' => {} }
+                 }
+               })
+      end
+
+      before do
+        Docker::Image.stub(:get).and_return(image_status)
+      end
+
+      it 'queries the Docker API with the base image name' do
+        expect(Docker::Image).to receive(:get).with(subject.from)
+        subject.default_exposed_ports
+      end
+
+      it 'assigns each exposed port to an array' do
+        expect(subject.default_exposed_ports).to match_array %w(3000/tcp)
+      end
+    end
+
+    context 'when default exposed ports exist' do
+
+      let(:image_status) do
+        double(:image_status,
+               info: {
+                 'Config' => {
+                   'ExposedPorts' => nil
+                 }
+               })
+      end
+
+      before do
+        Docker::Image.stub(:get).and_return(image_status)
+      end
+
+      it 'queries the Docker API with the base image name' do
+        expect(Docker::Image).to receive(:get).with(subject.from)
+        subject.default_exposed_ports
+      end
+
+      it 'returns an empty array' do
+        expect(subject.default_exposed_ports).to be_a(Array)
+        expect(subject.default_exposed_ports.length).to eql(0)
+      end
+    end
+
+    context 'when there is a Docker error' do
+
+      before do
+        Docker::Image.stub(:get).and_raise(Docker::Error::DockerError)
+      end
+
+      it 'queries the Docker API with the base image name' do
+        expect(Docker::Image).to receive(:get).with(subject.from)
+        subject.default_exposed_ports
+      end
+
+      it 'returns an empty array' do
+        expect(subject.default_exposed_ports).to be_a(Array)
+        expect(subject.default_exposed_ports.length).to eql(0)
+      end
+    end
+
+  end
+
   describe '#update_with_relationships' do
 
     let(:attrs) { { name: 'new_name' } }

--- a/spec/serializers/service_serializer_spec.rb
+++ b/spec/serializers/service_serializer_spec.rb
@@ -1,7 +1,21 @@
 require 'spec_helper'
 
 describe ServiceSerializer do
+
   let(:service_model) { Service.new }
+
+  let(:image_status) do
+    double(:image_status,
+      info: {
+        'Config' => {
+          'ExposedPorts' => {'3000/tcp' => {} }
+        }
+      })
+  end
+
+  before do
+    Docker::Image.stub(:get).and_return(image_status)
+  end
 
   it 'exposes the attributes to be jsonified' do
     serialized = described_class.new(service_model).as_json
@@ -23,7 +37,8 @@ describe ServiceSerializer do
       :sub_state,
       :type,
       :errors,
-      :docker_status
+      :docker_status,
+      :default_exposed_ports
     ]
     expect(serialized.keys).to match_array expected_keys
   end


### PR DESCRIPTION
Return a list of ports exposed by the base image alongside the user-exposed ports on a service. We want to differentiate between these to preserve the template-defined state.

```
{
    ...
    "expose": [],
    "default_exposed_ports": [
        "6379/tcp"
    ],
    ...
}
```
