### PR TITLE
Catch exception when github token is unscoped for email.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ActiveRecord::Base
   def retrieve_from_github(resource, default=nil)
     result = github_client.send(resource)
     block_given? ? yield(result) : result
-  rescue Octokit::Unauthorized
+  rescue Octokit::NotFound, Octokit::Unauthorized
     default
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -161,6 +161,19 @@ describe User do
         expect(subject.email).to be_nil
       end
     end
+
+    context 'when the github token is unscoped for email' do
+
+      before do
+        fake_gh_client.stub(:emails)
+        .and_raise(Octokit::NotFound)
+      end
+
+      it 'returns nil' do
+        expect(subject.email).to be_nil
+      end
+    end
+
   end
 
   describe '#github_username' do


### PR DESCRIPTION
Finishes [#80211040]

If the github token is unscoped for emails but the token is valid, Octokit was throwing an exception of `Octokit::NotFound`, while Panamax was trying to access emails. This fix catches the exception and thereby returning `nil`, which in turn is caught by the UI to display an appropriate error alert message.
