### PR TITLE
Disable remote agent SSL verification in dev mode

### DIFF
--- a/app/models/deployment_target.rb
+++ b/app/models/deployment_target.rb
@@ -81,7 +81,7 @@ class DeploymentTarget < ActiveRecord::Base
       self.ssl_options = {
         verify_mode: OpenSSL::SSL::VERIFY_PEER,
         ca_file: cert_file
-      }
+      } unless Rails.env.development?
     end
   end
 end


### PR DESCRIPTION
Disabling SSL verification in dev mode just to make local development easier. There is a similar commit on the remote agent side to disable SSL connections when running in development mode.
