### PR TITLE
Bring in webmock and bandaid some failures.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ group :test do
   gem 'coveralls', '0.7.0'
   gem 'shoulda-matchers', '2.6.1'
   gem 'database_cleaner', '1.3.0'
+  gem 'webmock', '1.20.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     database_cleaner (1.3.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -110,6 +112,7 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
+    safe_yaml (1.0.4)
     sawyer (0.5.4)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
@@ -141,6 +144,9 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    webmock (1.20.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
 
 PLATFORMS
   ruby
@@ -160,3 +166,4 @@ DEPENDENCIES
   rspec-rails (= 2.14.2)
   shoulda-matchers (= 2.6.1)
   sqlite3 (= 1.3.9)
+  webmock (= 1.20.0)

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ServicesController do
+describe ServicesController, :allow_net_connect do
   let(:app) { App.first }
 
   let(:image_status) do

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe App do
+describe App, :allow_net_connect do
   subject { apps(:app1) }
   it { should have_many(:services) }
   it { should have_many(:categories).class_name('AppCategory').dependent(:destroy) }

--- a/spec/serializers/service_serializer_spec.rb
+++ b/spec/serializers/service_serializer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ServiceSerializer do
+describe ServiceSerializer, :allow_net_connect do
 
   let(:service_model) { Service.new }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rspec/rails'
 require 'rspec/autorun'
 require 'coveralls'
 require 'simplecov'
+require 'webmock/rspec'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
   SimpleCov::Formatter::HTMLFormatter,
@@ -91,6 +92,10 @@ RSpec.configure do |config|
   config.after(:each) do
     FileUtils.rm_rf('dummy_certs')
   end
+
+  # This will be the Rspec 3 default and can be safely removed upon
+  # upgrade.
+  config.treat_symbols_as_metadata_keys_with_true_values = true
 end
 
 def fixture_data(filename, path='support/fixtures')

--- a/spec/support/allow_net_connect.rb
+++ b/spec/support/allow_net_connect.rb
@@ -1,0 +1,6 @@
+# This metadata, which is hopefully temporary, allows some specs to make
+# network connections that currently are.
+RSpec.configure do |c|
+  c.before(allow_net_connect: true) { WebMock.allow_net_connect! }
+  c.after { WebMock.disable_net_connect! }
+end


### PR DESCRIPTION
I'm adding webmock in anticipation of some integration-style tests for communication with the remote agent. I consulted a little with @bdehamer and @alexwelch on how this should work.

We're going with the default webmock behavior (raising an exception when a network connection happens), but using a metadata flag to allow some tests to behave as they currently do. When we have a minute we'll probably go through and figure out if there are missing stubs in those tests that are causing them to hit the network.
