### PR TITLE
Use an in-memory sqlite database in test mode.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,14 +9,11 @@ development:
   pool: 5
   timeout: 5000
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
+# See corresponding schema load in spec/support/in_memory_database
 test:
   adapter: sqlite3
-  database: db/mnt/test.sqlite3
-  pool: 5
-  timeout: 5000
+  database: ":memory:"
+  verbosity: quiet
 
 production:
   adapter: sqlite3

--- a/spec/support/in_memory_database.rb
+++ b/spec/support/in_memory_database.rb
@@ -1,0 +1,6 @@
+# Loads the schema into the in-memory database.
+schema_loader = -> { load Rails.root.join("db", "schema.rb") }
+
+# Without this it will spit out the output of the schema load at the
+# start of every test run.
+silence_stream(STDOUT, &schema_loader)


### PR DESCRIPTION
This speeds up the tests a bit without any tradeoff that I am aware of.
