### PR TITLE
Default to no root in AM::Serializers.

### DIFF
--- a/app/serializers/app_category_serializer.rb
+++ b/app/serializers/app_category_serializer.rb
@@ -1,5 +1,3 @@
 class AppCategorySerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :name, :position
 end

--- a/app/serializers/app_lite_serializer.rb
+++ b/app/serializers/app_lite_serializer.rb
@@ -1,5 +1,3 @@
 class AppLiteSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :name
 end

--- a/app/serializers/app_serializer.rb
+++ b/app/serializers/app_serializer.rb
@@ -1,6 +1,4 @@
 class AppSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :name, :from, :errors, :documentation
 
   has_many :categories, serializer: AppCategorySerializer

--- a/app/serializers/deployment_target_serializer.rb
+++ b/app/serializers/deployment_target_serializer.rb
@@ -1,5 +1,3 @@
 class DeploymentTargetSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :name, :endpoint_url, :auth_blob
 end

--- a/app/serializers/image_serializer.rb
+++ b/app/serializers/image_serializer.rb
@@ -1,6 +1,4 @@
 class ImageSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :category, :name, :source, :description, :type, :expose,
     :ports, :links, :environment, :volumes, :volumes_from, :command
 

--- a/app/serializers/local_image_search_result_serializer.rb
+++ b/app/serializers/local_image_search_result_serializer.rb
@@ -1,6 +1,4 @@
 class LocalImageSearchResultSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :source, :tags, :description, :is_official, :is_trusted, :star_count
 
   def source

--- a/app/serializers/registry_serializer.rb
+++ b/app/serializers/registry_serializer.rb
@@ -1,5 +1,3 @@
 class RegistrySerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :name, :endpoint_url, :enabled
 end

--- a/app/serializers/remote_image_search_result_serializer.rb
+++ b/app/serializers/remote_image_search_result_serializer.rb
@@ -1,6 +1,4 @@
 class RemoteImageSearchResultSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :source, :description, :is_official, :is_trusted, :star_count, :registry_id, :registry_name
 
   def source

--- a/app/serializers/repository_serializer.rb
+++ b/app/serializers/repository_serializer.rb
@@ -1,6 +1,4 @@
 class RepositorySerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :tags
 
   def id

--- a/app/serializers/service_category_serializer.rb
+++ b/app/serializers/service_category_serializer.rb
@@ -1,6 +1,4 @@
 class ServiceCategorySerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :name, :position
 
   def id

--- a/app/serializers/service_link_serializer.rb
+++ b/app/serializers/service_link_serializer.rb
@@ -1,6 +1,4 @@
 class ServiceLinkSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :service_id, :service_name, :alias, :errors
 
   def service_id

--- a/app/serializers/service_serializer.rb
+++ b/app/serializers/service_serializer.rb
@@ -1,6 +1,4 @@
 class ServiceSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :name, :description, :from, :ports, :expose, :default_exposed_ports, :environment,
     :volumes, :command, :load_state, :active_state, :sub_state, :type, :errors,
     :docker_status

--- a/app/serializers/shared_volume_serializer.rb
+++ b/app/serializers/shared_volume_serializer.rb
@@ -1,6 +1,4 @@
 class SharedVolumeSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :service_id, :service_name, :errors
 
   def service_id

--- a/app/serializers/template_file_serializer.rb
+++ b/app/serializers/template_file_serializer.rb
@@ -27,8 +27,6 @@ class TemplateFileSerializer < ActiveModel::Serializer
     end
   end
 
-  self.root = false
-
   attributes :name, :description, :keywords, :type, :documentation
 
   has_many :images, serializer: TemplateFileImageSerializer

--- a/app/serializers/template_repo_provider_serializer.rb
+++ b/app/serializers/template_repo_provider_serializer.rb
@@ -1,6 +1,4 @@
 class TemplateRepoProviderSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :name
 
 end

--- a/app/serializers/template_repo_serializer.rb
+++ b/app/serializers/template_repo_serializer.rb
@@ -1,6 +1,4 @@
 class TemplateRepoSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :name, :template_count, :updated_at
 
   def template_count

--- a/app/serializers/template_serializer.rb
+++ b/app/serializers/template_serializer.rb
@@ -1,6 +1,4 @@
 class TemplateSerializer < ActiveModel::Serializer
-  self.root = false
-
   attributes :id, :name, :description, :keywords, :source, :type, :image_count, :created_at, :updated_at,
              :documentation
 

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,6 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
-  self.root = false
-
   GROUPED_ATTRS = %i(email repos username)
 
   attributes *GROUPED_ATTRS

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,1 +1,2 @@
+ActiveModel::Serializer.root = false
 ActiveModel::ArraySerializer.root = false


### PR DESCRIPTION
This will just enforce consistency for new people like me who don't think to remove the root when creating a new serializer.
