### PR TITLE
Fixing specs which were trying to make net calls

### DIFF
--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ServicesController, :allow_net_connect do
+describe ServicesController do
   let(:app) { App.first }
 
   let(:image_status) do
@@ -14,6 +14,9 @@ describe ServicesController, :allow_net_connect do
 
   before do
     Docker::Image.stub(:get).and_return(image_status)
+
+    # Prevent any API calls for retrieving service status
+    Service.any_instance.stub(:service_state).and_return({})
   end
 
   describe '#index' do

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
-describe App, :allow_net_connect do
+describe App do
   subject { apps(:app1) }
+
+  before do
+    Service.any_instance.stub(:shutdown)
+  end
+
   it { should have_many(:services) }
   it { should have_many(:categories).class_name('AppCategory').dependent(:destroy) }
 

--- a/spec/serializers/service_serializer_spec.rb
+++ b/spec/serializers/service_serializer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ServiceSerializer, :allow_net_connect do
+describe ServiceSerializer do
 
   let(:service_model) { Service.new }
 
@@ -15,6 +15,9 @@ describe ServiceSerializer, :allow_net_connect do
 
   before do
     Docker::Image.stub(:get).and_return(image_status)
+
+    # Prevent any API calls for retrieving service status
+    Service.any_instance.stub(:service_state).and_return({})
   end
 
   it 'exposes the attributes to be jsonified' do

--- a/spec/support/allow_net_connect.rb
+++ b/spec/support/allow_net_connect.rb
@@ -1,6 +1,0 @@
-# This metadata, which is hopefully temporary, allows some specs to make
-# network connections that currently are.
-RSpec.configure do |c|
-  c.before(allow_net_connect: true) { WebMock.allow_net_connect! }
-  c.after { WebMock.disable_net_connect! }
-end


### PR DESCRIPTION
When @dpetersen added WebMock he discovered that some of our specs were trying to make API calls (and failing silently). As a temp fix, he added some code which would allow them to continue hitting the network.

This PR fixes the specs and removes Don's `:allow_net_connect` workaround.
