### PR TITLE
Split DeploymentTarget.deployments into a module.

### DIFF
--- a/app/models/deployment_target.rb
+++ b/app/models/deployment_target.rb
@@ -1,36 +1,11 @@
 require 'active_resource'
 
 class DeploymentTarget < ActiveRecord::Base
+  include Deployments
   using FileReader
 
   validates :name, presence: true, uniqueness: true
   validates :auth_blob, auth_blob: true
-
-  def list_deployments
-    with_remote_deployment_model do |model|
-      model.all
-    end
-  end
-
-  def get_deployment(deployment_id)
-    with_remote_deployment_model do |model|
-      model.find(deployment_id)
-    end
-  end
-
-  def create_deployment(template, override)
-    with_remote_deployment_model do |model|
-      model.create(
-        template: TemplateFileSerializer.new(template),
-        override: TemplateFileSerializer.new(override))
-    end
-  end
-
-  def delete_deployment(deployment_id)
-    with_remote_deployment_model do |model|
-      model.delete(deployment_id)
-    end
-  end
 
   def public_cert
     auth_parts[3]
@@ -52,32 +27,5 @@ class DeploymentTarget < ActiveRecord::Base
 
   def auth_parts
     Base64.decode64(auth_blob.to_s).split('|')
-  end
-
-  def with_remote_deployment_model
-    Tempfile.open(name.to_s.downcase) do |file|
-      file.write(public_cert)
-      file.rewind
-      yield(remote_deployment_model(file))
-    end
-  end
-
-  # Class for Deployment model is dynamically generated because we need
-  # to be able to set the site at runtime based on the endpoint for the
-  # specific deployment target
-  def remote_deployment_model(cert_file)
-    target = self
-
-    Class.new(RemoteDeployment) do
-      self.site = target.endpoint_url
-      self.element_name = 'deployment'
-      self.user = target.username
-      self.password = target.password
-
-      self.ssl_options = {
-        verify_mode: OpenSSL::SSL::VERIFY_PEER,
-        ca_file: cert_file.path
-      } unless Rails.env.development?
-    end
   end
 end

--- a/app/models/deployment_target/deployments.rb
+++ b/app/models/deployment_target/deployments.rb
@@ -1,0 +1,56 @@
+module DeploymentTarget::Deployments
+  def list_deployments
+    with_remote_deployment_model do |model|
+      model.all
+    end
+  end
+
+  def get_deployment(deployment_id)
+    with_remote_deployment_model do |model|
+      model.find(deployment_id)
+    end
+  end
+
+  def create_deployment(template, override)
+    with_remote_deployment_model do |model|
+      model.create(
+        template: TemplateFileSerializer.new(template),
+        override: TemplateFileSerializer.new(override))
+    end
+  end
+
+  def delete_deployment(deployment_id)
+    with_remote_deployment_model do |model|
+      model.delete(deployment_id)
+    end
+  end
+
+protected
+
+  def with_remote_deployment_model
+    Tempfile.open(name.to_s.downcase) do |file|
+      file.write(public_cert)
+      file.rewind
+      yield(remote_deployment_model(file))
+    end
+  end
+
+  # Class for Deployment model is dynamically generated because we need
+  # to be able to set the site at runtime based on the endpoint for the
+  # specific deployment target
+  def remote_deployment_model(cert_file)
+    target = self
+
+    Class.new(RemoteDeployment) do
+      self.site = target.endpoint_url
+      self.element_name = 'deployment'
+      self.user = target.username
+      self.password = target.password
+
+      self.ssl_options = {
+        verify_mode: OpenSSL::SSL::VERIFY_PEER,
+        ca_file: cert_file.path
+      } unless Rails.env.development?
+    end
+  end
+end

--- a/spec/models/deployment_target/deployments_spec.rb
+++ b/spec/models/deployment_target/deployments_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+describe DeploymentTarget do
+  describe '#with_remote_deployment_model' do
+    let(:certificate_contents) { 'certificate of authenticity' }
+
+    before do
+      subject.auth_blob = Base64.encode64("a|b|c|#{certificate_contents}")
+    end
+
+    it 'writes the file before calling the block' do
+      subject.should_receive(:remote_deployment_model).with do |cert_file|
+        expect(cert_file.read).to eq certificate_contents
+      end
+      subject.send(:with_remote_deployment_model) { |model| model }
+    end
+  end
+
+  describe '#remote_deployment_model' do
+    let(:fake_temp_file) { double(:fake_temp_file, path: 'certs/foo.crt') }
+    let(:remote_deployment_model) { subject.send(:remote_deployment_model, fake_temp_file) }
+
+    it 'sets the proper user' do
+      subject.auth_blob = Base64.encode64('a|bob|c|d')
+      expect(remote_deployment_model.user).to eq 'bob'
+    end
+
+    it 'sets the proper password' do
+      subject.auth_blob = Base64.encode64('a|b|abc123|d')
+      expect(remote_deployment_model.password).to eq 'abc123'
+    end
+
+    it 'sets the proper site_url' do
+      subject.auth_blob = Base64.encode64('example.com|b|c|d')
+      expect(remote_deployment_model.site.to_s).to eq 'example.com'
+    end
+
+    it 'sets the proper element_name' do
+      expect(remote_deployment_model.element_name).to eq 'deployment'
+    end
+
+    it 'sets the proper ssl options' do
+      expect(remote_deployment_model.ssl_options).to eq({
+        verify_mode: OpenSSL::SSL::VERIFY_PEER,
+        ca_file: 'certs/foo.crt'
+      })
+    end
+  end
+
+  describe '#list_deployments' do
+    let(:remote_deployments) do
+      [
+        RemoteDeployment.new,
+        RemoteDeployment.new
+      ]
+    end
+
+    before do
+      RemoteDeployment.stub(:all).and_return(remote_deployments)
+    end
+
+    it 'lists the remote deployments' do
+      expect(subject.list_deployments).to eq remote_deployments
+    end
+  end
+
+  describe '#get_deployment' do
+    let(:remote_deployment) { RemoteDeployment.new }
+
+    before do
+      RemoteDeployment.stub(:find).with(32).and_return(remote_deployment)
+    end
+
+    it 'retrieves the specified deployment' do
+      expect(subject.get_deployment(32)).to eq remote_deployment
+    end
+  end
+
+  describe '#create_deployment' do
+    let(:template) do
+      {
+        'name' => 'Wordpress Application',
+        'description' => 'a blog'
+      }
+    end
+
+    let(:override) do
+      {
+        'name' => 'Wordpress Application',
+        'description' => 'a glob'
+      }
+    end
+
+    it 'creates the deployment' do
+      expect(RemoteDeployment).to receive(:create) do |opts|
+        expect(opts.keys).to match_array([:template, :override])
+        expect(opts[:template]).to be_kind_of(TemplateFileSerializer)
+        expect(opts[:template].object).to eq template
+        expect(opts[:override]).to be_kind_of(TemplateFileSerializer)
+        expect(opts[:override].object).to eq override
+      end
+      subject.create_deployment(template, override)
+    end
+  end
+
+  describe '#delete_deployment' do
+    it 'deletes the supplied deployment' do
+      expect(RemoteDeployment).to receive(:delete).with(33)
+      subject.delete_deployment(33)
+    end
+  end
+end

--- a/spec/models/deployment_target_spec.rb
+++ b/spec/models/deployment_target_spec.rb
@@ -2,29 +2,6 @@ require 'spec_helper'
 
 describe DeploymentTarget do
 
-  let(:template) do
-    {
-      'name' => 'Wordpress Application',
-      'description' => 'a blog'
-    }
-  end
-
-  let(:override) do
-    {
-      'name' => 'Wordpress Application',
-      'description' => 'a glob'
-    }
-  end
-
-  let(:remote_deployment) { RemoteDeployment.new }
-
-  let(:remote_deployments) do
-    [
-      RemoteDeployment.new,
-      RemoteDeployment.new
-    ]
-  end
-
   describe 'validations' do
     it { should validate_presence_of :name }
     it { should validate_uniqueness_of :name }
@@ -64,92 +41,6 @@ describe DeploymentTarget do
     it 'gets the public cert from the instance' do
       subject.auth_blob = Base64.encode64('a|b|c|certificate of authenticity')
       expect(subject.public_cert).to eq 'certificate of authenticity'
-    end
-  end
-
-  describe '#with_remote_deployment_model' do
-    let(:certificate_contents) { 'certificate of authenticity' }
-
-    before do
-      subject.auth_blob = Base64.encode64("a|b|c|#{certificate_contents}")
-    end
-
-    it 'writes the file before calling the block' do
-      subject.should_receive(:remote_deployment_model).with do |cert_file|
-        expect(cert_file.read).to eq certificate_contents
-      end
-      subject.send(:with_remote_deployment_model) { |model| model }
-    end
-  end
-
-  describe '#remote_deployment_model' do
-    let(:fake_temp_file) { double(:fake_temp_file, path: 'certs/foo.crt') }
-    let(:remote_deployment_model) { subject.send(:remote_deployment_model, fake_temp_file) }
-
-    it 'sets the proper user' do
-      subject.auth_blob = Base64.encode64('a|bob|c|d')
-      expect(remote_deployment_model.user).to eq 'bob'
-    end
-
-    it 'sets the proper password' do
-      subject.auth_blob = Base64.encode64('a|b|abc123|d')
-      expect(remote_deployment_model.password).to eq 'abc123'
-    end
-
-    it 'sets the proper site_url' do
-      subject.auth_blob = Base64.encode64('example.com|b|c|d')
-      expect(remote_deployment_model.site.to_s).to eq 'example.com'
-    end
-
-    it 'sets the proper element_name' do
-      expect(remote_deployment_model.element_name).to eq 'deployment'
-    end
-
-    it 'sets the proper ssl options' do
-      expect(remote_deployment_model.ssl_options).to eq({
-        verify_mode: OpenSSL::SSL::VERIFY_PEER,
-        ca_file: 'certs/foo.crt'
-      })
-    end
-  end
-
-  describe '#list_deployments' do
-    before do
-      RemoteDeployment.stub(:all).and_return(remote_deployments)
-    end
-
-    it 'lists the remote deployments' do
-      expect(subject.list_deployments).to eq remote_deployments
-    end
-  end
-
-  describe '#get_deployment' do
-    before do
-      RemoteDeployment.stub(:find).with(32).and_return(remote_deployment)
-    end
-
-    it 'retrieves the specified deployment' do
-      expect(subject.get_deployment(32)).to eq remote_deployment
-    end
-  end
-
-  describe '#create_deployment' do
-    it 'creates the deployment' do
-      expect(RemoteDeployment).to receive(:create) do |opts|
-        expect(opts.keys).to match_array([:template, :override])
-        expect(opts[:template]).to be_kind_of(TemplateFileSerializer)
-        expect(opts[:template].object).to eq template
-        expect(opts[:override]).to be_kind_of(TemplateFileSerializer)
-        expect(opts[:override].object).to eq override
-      end
-      subject.create_deployment(template, override)
-    end
-  end
-
-  describe '#delete_deployment' do
-    it 'deletes the supplied deployment' do
-      expect(RemoteDeployment).to receive(:delete).with(33)
-      subject.delete_deployment(33)
     end
   end
 end


### PR DESCRIPTION
I've split this into a separate PR to make the metadata one easier to read. This is a lot of lines but very few actual changes.

I'm about to add another related resource for metadata, so this seemed
like a good idea. There were a number of things at the top of the test
that only pertained to the deployments resource, so that is probably
easier to read now. I almost moved the cert-related items into their own
concern but stopped myself.
