### PR TITLE
Add Status model for use by deployment API

### DIFF
--- a/app/models/deployment_target.rb
+++ b/app/models/deployment_target.rb
@@ -74,6 +74,8 @@ class DeploymentTarget < ActiveRecord::Base
       self.user = target.username
       self.password = target.password
 
+      has_one :status, class_name: Status
+
       self.ssl_options = {
         verify_mode: OpenSSL::SSL::VERIFY_PEER,
         ca_file: cert_file.path

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,7 @@
+class Status < ApiModel
+  attr_accessor :overall, :services
+
+  def initialize(attrs={}, persisted=false)
+    super attrs
+  end
+end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Status do
+
+  it_behaves_like 'an api model'
+
+  describe 'attributes' do
+    it { should respond_to :overall }
+    it { should respond_to :services }
+  end
+
+  describe '#initialize' do
+
+    let(:attrs) { { overall: 'running', services: [] } }
+
+    subject { described_class.new(attrs) }
+
+    it 'initializes the object with the passed-in attrs' do
+      expect(subject.overall).to eq attrs[:overall]
+      expect(subject.services).to eq attrs[:services]
+    end
+  end
+
+end


### PR DESCRIPTION
The introduction of the `Status` model allows us to short-circuit the automatic class-instantiation logic that is used by ActiveResource. In this case the deployment response includes a collection named 'services' but we don't want AR to instantiate `Service` models.

[#82324094]
