### PR TITLE
Explicitly define required fixtures in tests.

### DIFF
--- a/spec/builders/app_builder/from_image_spec.rb
+++ b/spec/builders/app_builder/from_image_spec.rb
@@ -5,6 +5,8 @@ describe AppBuilder::FromImage do
   describe '.create_app' do
 
     context 'when a registry id is supplied' do
+      fixtures :registries
+
       let(:registry) { registries(:registry1) }
       let(:options) do
         {

--- a/spec/builders/app_builder/from_template_spec.rb
+++ b/spec/builders/app_builder/from_template_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe AppBuilder::FromTemplate do
 
   describe '.create_app' do
+    fixtures :templates
 
     let(:template) { templates(:wordpress) }
     let(:app) { App.new(name: 'myapp') }

--- a/spec/builders/template_builder/from_app_spec.rb
+++ b/spec/builders/template_builder/from_app_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe TemplateBuilder::FromApp do
+  fixtures :apps
 
   let(:options) do
     {

--- a/spec/builders/template_builder_spec.rb
+++ b/spec/builders/template_builder_spec.rb
@@ -13,6 +13,7 @@ describe TemplateBuilder do
   describe '.create' do
 
     context 'when an app_id is passed' do
+      fixtures :apps
       before { options[:app_id] = apps(:app1).id }
 
       it 'returns a template created from the application' do

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe AppsController do
+  fixtures :apps
 
   describe '#index' do
 
@@ -54,7 +55,7 @@ describe AppsController do
   end
 
   describe '#create' do
-
+    fixtures :templates
     let(:template) { templates(:wordpress) }
 
     before do

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe CategoriesController do
-
+  fixtures :apps, :app_categories
   let(:app) { apps(:app1) }
 
   describe '#index' do

--- a/spec/controllers/deployment_targets_controller_spec.rb
+++ b/spec/controllers/deployment_targets_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe DeploymentTargetsController do
-
+  fixtures :deployment_targets
   let(:deployment_target) { deployment_targets(:target1) }
 
   describe 'GET #index' do

--- a/spec/controllers/keywords_controller_spec.rb
+++ b/spec/controllers/keywords_controller_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe KeywordsController do
 
   describe 'GET #index' do
+    fixtures :templates
+
     it 'returns all the keywords as JSON' do
       expected = [
         { keyword: 'blah', count: 1 },

--- a/spec/controllers/registries_controller_spec.rb
+++ b/spec/controllers/registries_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RegistriesController do
-
+  fixtures :registries
   let(:registry) { registries(:registry1) }
 
   describe 'GET #index' do

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -142,6 +142,7 @@ describe SearchController do
       end
 
       context 'querying templates' do
+        fixtures :templates
         let(:query) { 'wordpress' }
 
         before do

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe ServicesController do
-  let(:app) { App.first }
-
   let(:image_status) do
     double(:image_status,
            info: {
@@ -20,6 +18,8 @@ describe ServicesController do
   end
 
   describe '#index' do
+    fixtures :apps
+    let(:app) { App.first }
 
     it 'returns an array' do
       get :index, app_id: app.id, format: :json
@@ -29,6 +29,8 @@ describe ServicesController do
   end
 
   describe '#show' do
+    fixtures :apps, :services
+    let(:app) { App.first }
 
     it 'returns a specific app' do
       get :show, app_id: app.id, id: Service.first.id, format: :json
@@ -175,6 +177,8 @@ describe ServicesController do
   end
 
   describe '#journal' do
+    fixtures :apps, :services
+    let(:app) { App.first }
 
     it 'returns the service journal' do
       get :journal, app_id: app.id, id: Service.first.id, format: :json
@@ -203,6 +207,7 @@ describe ServicesController do
   end
 
   describe '#create' do
+    fixtures :apps, :services
     let(:app) { apps(:app1) }
 
     let(:params) do

--- a/spec/controllers/template_repos_controller_spec.rb
+++ b/spec/controllers/template_repos_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe TemplateReposController do
+  fixtures :template_repos, :template_repo_providers
 
   describe '#index' do
 

--- a/spec/controllers/templates_controller_spec.rb
+++ b/spec/controllers/templates_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe TemplatesController do
+  fixtures :templates
 
   describe 'GET templates' do
 
@@ -92,6 +93,7 @@ describe TemplatesController do
   end
 
   describe '#save' do
+    fixtures :template_repo_providers
     let(:template) { Template.first }
     let(:save_response) do
       { content:

--- a/spec/lib/panamax_agent/journal/client_spec.rb
+++ b/spec/lib/panamax_agent/journal/client_spec.rb
@@ -22,13 +22,13 @@ describe PanamaxAgent::Journal::Client do
         }
       ]
     end
+    let(:services) { 'foo' }
 
     before do
       subject.stub(:get_entries_by_fields).and_return(journal_lines)
     end
 
     it 'invokes the get_entries_by_fields method' do
-      services = 'foo'
       cursor = 'bar'
       expect(subject).to receive(:get_entries_by_fields).with({}, cursor)
       subject.list_journal_entries(services, cursor)

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe App do
+  fixtures :apps
   subject { apps(:app1) }
 
   before do
@@ -72,8 +73,7 @@ describe App do
   end
 
   describe '#add_service' do
-
-    fixtures :app_categories
+    fixtures :app_categories, :services
 
     let(:category) { subject.categories.first }
     let(:linked_to_service) { subject.services.last }

--- a/spec/models/converters/app_converter_spec.rb
+++ b/spec/models/converters/app_converter_spec.rb
@@ -5,6 +5,8 @@ describe Converters::AppConverter do
   subject { described_class.new(apps(:app1)) }
 
   context '#to_template' do
+    fixtures :apps
+
     it 'creates a Template from the given App' do
       expect(subject.to_template).to be_a Template
     end

--- a/spec/models/converters/service_converter_spec.rb
+++ b/spec/models/converters/service_converter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Converters::ServiceConverter do
-
+  fixtures :services
   let(:service1) { services(:service1) }
   subject { described_class.new(service1) }
 
@@ -65,6 +65,8 @@ describe Converters::ServiceConverter do
       before do
         service1.categories.build(app_category: app_categories(:category1))
       end
+
+      it "TODO for Brian: has no test to trigger this fixture call"
     end
 
     context 'when handling services with volumes_from' do

--- a/spec/models/converters/template_converter_spec.rb
+++ b/spec/models/converters/template_converter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Converters::TemplateConverter do
 
   describe '#to_app' do
-
+    fixtures :templates
     let(:template) { templates(:wordpress) }
 
     subject { Converters::TemplateConverter.new(template) }

--- a/spec/models/github_template_repo_provider_spec.rb
+++ b/spec/models/github_template_repo_provider_spec.rb
@@ -204,6 +204,7 @@ describe GithubTemplateRepoProvider do
   end
 
   describe '#save_template' do
+    fixtures :templates
     let(:template) { Template.first }
     let(:contents_response) { double(:contents_response, sha: 'ccccccc') }
     let(:params) do

--- a/spec/models/registry_spec.rb
+++ b/spec/models/registry_spec.rb
@@ -13,6 +13,8 @@ describe Registry do
   it { should validate_presence_of(:endpoint_url) }
 
   describe '.docker_hub' do
+    fixtures :registries
+
     it 'returns the special docker hub record' do
       expect(described_class.docker_hub.id).to eq 0
       expect(described_class.docker_hub.name).to eq 'Docker Hub'
@@ -21,6 +23,7 @@ describe Registry do
   end
 
   describe ".enabled" do
+    fixtures :registries
     subject { Registry.enabled }
     before { registries(:registry0).update_attribute(:enabled, false) }
 
@@ -59,6 +62,7 @@ describe Registry do
   end
 
   describe '#search' do
+    fixtures :registries
     let(:registry) { registries(:registry0) }
     subject(:search) { registry.search("test") }
 
@@ -158,6 +162,7 @@ describe Registry do
 
   describe '#prefix' do
     context 'when the registry is docker hub' do
+      fixtures :registries
       let(:docker_hub) { registries(:registry0) }
       subject { docker_hub.prefix }
 

--- a/spec/models/template_repo_spec.rb
+++ b/spec/models/template_repo_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe TemplateRepo do
+  fixtures :template_repo_providers, :template_repos
+
   it { should respond_to(:name) }
   it { should respond_to(:template_repo_provider) }
   it { should validate_uniqueness_of(:name) }

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -8,6 +8,7 @@ describe Template do
   it { should validate_presence_of(:name) }
 
   describe '.all_keywords' do
+    fixtures :templates
     before do
       templates(:wordpress).update(keywords: 'wordpress, sizzle, two words')
       templates(:another).update(keywords: 'another,SiZzle')
@@ -25,6 +26,8 @@ describe Template do
   end
 
   describe '.search' do
+    fixtures :templates
+
     it 'returns templates with name or keyword matching the term' do
       expect(described_class.search('wp')).to match_array([templates(:wordpress), templates(:another)])
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe User do
+  fixtures :template_repo_providers
+
   let(:fake_gh_client) { Octokit::Client.new } # see spec_helper
 
   before do

--- a/spec/serializers/template_repo_serializer_spec.rb
+++ b/spec/serializers/template_repo_serializer_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe TemplateRepoSerializer do
+  fixtures :template_repo_providers
+
   let(:repo_model) { TemplateRepo.new }
 
   it 'exposes the attributes to be jsonified' do
@@ -14,8 +16,12 @@ describe TemplateRepoSerializer do
     expect(serialized.keys).to match_array expected_keys
   end
 
-  it 'calculates the Template count for the repository' do
-    template_count = Template.where(source: template_repos(:repo1).name).count
-    expect(TemplateRepoSerializer.new(template_repos(:repo1)).template_count).to eq template_count
+  context 'with existing TemplateRepos' do
+    fixtures :template_repos
+
+    it 'calculates the Template count for the repository' do
+      template_count = Template.where(source: template_repos(:repo1).name).count
+      expect(TemplateRepoSerializer.new(template_repos(:repo1)).template_count).to eq template_count
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,8 +55,6 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = 'random'
 
-  config.global_fixtures = :all
-
   config.before(:each) do
     # Stub methods on Docker client
     Docker::Container.stub(:get).and_return({})


### PR DESCRIPTION
The global fixture setting causes dozens of rows to be created and then
rolled back on every test. I feel like it's clearer when you're testing
(or reading the test) about what's involved with a system when you have
to state which fixtures you need in the context it will be used. It has
a side-effect of being significantly faster (23s to 9s on my test machine).

I tried to put each `fixtures` statement at the lowest context that it was required within reason. There are a number of cases (particularly controller specs) where a fixture is needed in 4 out of 5 contexts and I just dropped it at the root of the spec for conciseness. In a couple of cases (`apps_controller_spec` particularly) I had to be a little more verbose because half of the actions were tested with the real database records and half were mocking it out, and I wanted to be more explicit to make that clear.

In addition, while I was roaming around I found a couple of weird test cases where it looks like folks missed writing tests but did write text indicating that a test should exist. I'll call them out in comments based on the blame and see if they want to write the test or whether I should just delete them.
