### PR TITLE
Upgrade simplecov for Circle warning.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,9 +110,9 @@ GEM
       faraday (~> 0.8, < 0.10)
     shoulda-matchers (2.6.1)
       activesupport (>= 3.0.0)
-    simplecov (0.8.2)
+    simplecov (0.9.1)
       docile (~> 1.1.0)
-      multi_json
+      multi_json (~> 1.0)
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     sprockets (2.12.3)


### PR DESCRIPTION
Our Circle builds include the following warning:

Your version of Simplecov has a serious bug affecting exit codes! It can
cause your build to pass even when you have failing tests

There is a slightly newer version of coveralls (which is what brings in
simplecov), but it addresses a couple of edge cases that we don't seem
to care about. It works fine with the newer version of simplecov, so in
the interest of changing the fewest things I'm just upgrading simplecov.
