### PR TITLE
Send refresh flag to Dray

### DIFF
--- a/app/serializers/job_step_lite_serializer.rb
+++ b/app/serializers/job_step_lite_serializer.rb
@@ -1,5 +1,5 @@
 class JobStepLiteSerializer < ActiveModel::Serializer
-  attributes :source, :beginDelimiter, :endDelimiter
+  attributes :source, :beginDelimiter, :endDelimiter, :refresh
 
   def beginDelimiter
     '----BEGIN PANAMAX DATA----'
@@ -7,5 +7,9 @@ class JobStepLiteSerializer < ActiveModel::Serializer
 
   def endDelimiter
     '----END PANAMAX DATA----'
+  end
+
+  def refresh
+    true
   end
 end

--- a/spec/serializers/job_step_lite_serializer_spec.rb
+++ b/spec/serializers/job_step_lite_serializer_spec.rb
@@ -5,7 +5,7 @@ describe JobStepLiteSerializer do
 
   it 'exposes the attributes to be serialized' do
     serialized = described_class.new(job_step).as_json
-    expected_keys = [:source, :beginDelimiter, :endDelimiter]
+    expected_keys = [:source, :beginDelimiter, :endDelimiter, :refresh]
     expect(serialized.keys).to match_array expected_keys
   end
 end


### PR DESCRIPTION
Updating the `job_step_lite_serializer` so that the *refresh* flag is set to *true* for all steps when submitting jobs to Dray.

[#90615138]