### PR TITLE
Adding tzinfo-data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'fleet-api', '1.1.0', require: 'fleet'
 gem 'active_model_serializers', '0.9.0'
 gem 'octokit', '3.2.0'
 gem 'kmts', '2.0.1'
+gem 'tzinfo-data', '1.2015.2'
 
 group :test, :development do
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,8 @@ GEM
     tins (1.3.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2015.2)
+      tzinfo (>= 1.0.0)
     webmock (1.20.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -160,4 +162,5 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers (= 2.6.1)
   sqlite3 (= 1.3.9)
+  tzinfo-data (= 1.2015.2)
   webmock (= 1.20.0)


### PR DESCRIPTION
The new base image we're using does not include the standard `/usr/share/zoneinfo` directory that many other distros include by default. This data is needed by the *tzinfo* gem (which is required for *activesupport*). The *tzinfo-data* gem serves as an alternate source for the data typically found in the  `/usr/share/zoneinfo` directory.